### PR TITLE
Check if locale prop is set

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -124,7 +124,9 @@ export default class CalendarStrip extends Component {
 
     //Function that checks if the locale is passed to the component and sets it to the passed moment instance
     setLocale(momentInstance) {
-        momentInstance.locale(this.props.locale.name);
+        if (this.props.locale) {
+            momentInstance.locale(this.props.locale.name);
+        }
         return momentInstance;
     }
 


### PR DESCRIPTION
If you don't pass the locale prop, an error is thrown.

Please add defaultProps or, like my pull request, check if prop is set.