### PR TITLE
Add useIsoWeekday option to start week on ISO or given week day

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ This is the list of all the props you can pass to the component so that you can 
   * startingDate: React.PropTypes.any - Date to be used for centering the calendar/showing the week based on that date. It is internaly wrapped by `moment` so it accepts both `Date` and `moment Date`.
   * selectedDate: React.PropTypes.any - Date to be used as pre selected Date. It is internaly wrapped by `moment` so it accepts both `Date` and `moment Date`.
   * onDateSelected: React.PropTypes.func - Function to be used as a callback when a date is selected. It returns `moment Date`
- 
+  * useIsoWeekday: React.PropTypes.bool - start week on ISO day of week (default true).  If false, starts week on _startingDate_ parameter.
+
 ###### Top level style
   * style: React.PropTypes.any - Style for the top level CalendarStrip component
 
@@ -108,44 +109,44 @@ This is the list of all the props you can pass to the component so that you can 
   * dateNumberStyle: React.PropTypes.any - Style for the number of the day on work days in dates strip.
   * weekendDateNameStyle: React.PropTypes.any - Style for the name of the day on weekend days in dates strip.
   * weekendDateNumberStyle: React.PropTypes.any - Style for the number of the day on weekend days in dates strip.
-  
+
   ###### Animations
   There are two animated properties that also can be customized. The first one is actually animated showing of dates when you change a week.
   *If you do not add this prop, it will not have an animation*
   There are 2 possible options.
   * calendarAnimation: React.PropTypes.object - Animation object for showin the dates. It can have 2 types: `{type: 'sequence', duration: 30}` or `{type: 'parallel', duration: 300}` and the duration part being the duration of animation in millisecond.
-  
+
   ####### Sequence
   The animation is used to show dates in sequence, so it shows them one by one.
   ![alt text](https://raw.githubusercontent.com/BugiDev/react-native-calendar-strip/master/example/gifs/squential.gif "react-native-calendar-strip sequence animation demo")
-  
+
   ####### Parallel
   The animation is used to show dates in parallel, so it shows all of them with opacity animation.
   ![alt text](https://raw.githubusercontent.com/BugiDev/react-native-calendar-strip/master/example/gifs/parallel.gif "react-native-calendar-strip parallel animation demo")
-  
+
   ---
   The second animation is used to animate selection of the date. Again, there are 2 types of animation, and they are either animating circular border around a date or changing a circualar background of the date.
   * selection: React.PropTypes.string - String prop for type of selection highligh. Possible types are `border` or `background.` `!important` This property will only determen the type of selection and type of animation, but to be animated, properties bellow have to be added as well.
   * selectionAnimation: React.PropTypes.object - An object used for the animation of selection. If this object is added, only then the selection will be animated. This object defines `{duration: 30}` of the animation, and *if you add a type `border` of selection, you should also add a `{duration: 30, borderWidth: 1}` to this object.*
   * borderHighlightColor: React.PropTypes.string - Highlighting border color.
   ![alt text](https://raw.githubusercontent.com/BugiDev/react-native-calendar-strip/master/example/gifs/border-small.gif "react-native-calendar-strip border animation demo")
-  
+
   If you chose the `background` type of animation, the selected date will animate the circular background color from `calendarColor` to `highlightColor`. That is why, when this type is chosen, you have to define both of these colors.
   * calendarColor: React.PropTypes.string - Color of the circular backgroundo of the date. `!important` This color will also be aplied as the whole calendar strip background color, so that highlighting the date will appear 'from background' but be aware that top level style of this component can override this property.
   * highlightColor: React.PropTypes.string - Highlighting color of dates.
-  
+
   ![alt text](https://raw.githubusercontent.com/BugiDev/react-native-calendar-strip/master/example/gifs/background-small.gif "react-native-calendar-strip simple demo")
-  
+
 ###### Localization
   * locale: React.PropTypes.object - Locale for dates
-  
+
   This prop is used for adding localization to react-native-calendar-strip component. The localization rules are the same as moments and can be found in [moments documentation](http://momentjs.com/docs/#/i18n/)
-  
+
   The locale object has two properties:
   * `name` - String - The name of the locale (ex. 'fr')
   * `config` - Object - The config object holding all of the localization strings.
-  
-  Example of one locale object is: 
+
+  Example of one locale object is:
   ```
   const locale = {
               name: 'fr',
@@ -209,11 +210,10 @@ This is the list of all the props you can pass to the component so that you can 
               }
           };
   ```
-  
+
 #### ToDo
 
  * [ ] Add unit tests
  * [ ] Add Travis CI integration
  * [ ] Implement week view, which should show weeks in a month rather than days, so that you select the whole week
  * [ ] Add a month and a year selection in a form of a popup
-

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -155,7 +155,7 @@ export default class CalendarStrip extends Component {
               date = me.setLocale(moment(startDate.isoWeekday(index + 1)));
             }
             else {
-              date = me.setLocale(moment(startDate.add(1, 'days')));
+              date = me.setLocale(moment(startDate).add(index, 'days'));
             }
             dates.push(date);
         });

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -35,6 +35,7 @@ export default class CalendarStrip extends Component {
         startingDate: React.PropTypes.any,
         selectedDate: React.PropTypes.any,
         onDateSelected: React.PropTypes.func,
+        useIsoWeekday: React.PropTypes.bool,
 
         iconLeft: React.PropTypes.any,
         iconRight: React.PropTypes.any,
@@ -60,6 +61,7 @@ export default class CalendarStrip extends Component {
 
     static defaultProps = {
         startingDate: moment(),
+        useIsoWeekday: true,
         iconLeft: require('./img/left-arrow-black.png'),
         iconRight: require('./img/right-arrow-black.png'),
         calendarHeaderFormat: 'MMMM YYYY'
@@ -145,8 +147,16 @@ export default class CalendarStrip extends Component {
     getDatesForWeek() {
         const me = this;
         let dates = [];
+        let startDate = moment(this.state.startingDate);
+
         arr.forEach((item, index) => {
-            const date = me.setLocale(moment(me.state.startingDate.isoWeekday(index + 1)));
+            let date;
+            if (me.props.useIsoWeekday) {
+              date = me.setLocale(moment(startDate.isoWeekday(index + 1)));
+            }
+            else {
+              date = me.setLocale(moment(startDate.add(1, 'days')));
+            }
             dates.push(date);
         });
         return dates;


### PR DESCRIPTION
useIsoWeekday controls whether the start of the week is on the ISO week day (default, same as previous behavior) or the passed in startingDate day.
 