### PR TITLE
Fix startingDate bugs

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -191,8 +191,8 @@ export default class CalendarStrip extends Component {
 
     // Set the current visible week to the selectedDate
     updateWeekView(date, startDate = this.state.startingDate) {
-      let mDate = moment(date);
-      let daysDiff = mDate.diff(startDate, 'days');
+      let mDate = moment(date).startOf("day");
+      let daysDiff = mDate.diff(moment(startDate).startOf("day"), "days");
       let addOrSubtract = daysDiff > 0 ? 'add' : 'subtract';
       let adjustWeeks = daysDiff / 7;
       adjustWeeks = adjustWeeks > 0 ? Math.floor(adjustWeeks) : Math.ceil(Math.abs(adjustWeeks));

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -191,8 +191,8 @@ export default class CalendarStrip extends Component {
 
     // Set the current visible week to the selectedDate
     updateWeekView(date, startDate = this.state.startingDate) {
-      let mDate = moment(date).startOf("day");
-      let daysDiff = mDate.diff(moment(startDate).startOf("day"), "days");
+      let mDate = moment(date).startOf('day');
+      let daysDiff = mDate.diff(moment(startDate).startOf('day'), 'days');
       let addOrSubtract = daysDiff > 0 ? 'add' : 'subtract';
       let adjustWeeks = daysDiff / 7;
       adjustWeeks = adjustWeeks > 0 ? Math.floor(adjustWeeks) : Math.ceil(Math.abs(adjustWeeks));


### PR DESCRIPTION
The startingDate does not set itself correctly if no prop is passed in.   This causes issues showing the correct week when the selectedDate prop is used.  

You currently have to specify the startingDate prop when using the selectedDate prop.  This removes that requirement.

I suspect that this is the problem with issue https://github.com/BugiDev/react-native-calendar-strip/issues/27 amongst other things.


