### PR TITLE
Extracted CalendarHeader into its own component

### DIFF
--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -1,0 +1,63 @@
+import React, {Component} from 'react';
+import {Text} from 'react-native';
+
+import styles from './Calendar.style.js';
+
+class CalendarHeader extends Component {
+    static propTypes = {
+        calendarHeaderFormat: React.PropTypes.string,
+        calendarHeaderStyle: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number
+        ]),
+        datesForWeek: React.PropTypes.array.isRequired
+    };
+
+    shouldComponentUpdate(nextProps) {
+        return JSON.stringify(this.props) !== JSON.stringify( nextProps );
+    }
+
+
+    //Function that formats the calendar header
+    //It also formats the month section if the week is in between months
+    formatCalendarHeader(datesForWeek, calendarHeaderFormat) {
+        if (!datesForWeek || datesForWeek.length === 0) {
+            return '';
+        }
+
+        let firstDay = datesForWeek[0];
+        let lastDay = datesForWeek[datesForWeek.length - 1];
+        let monthFormatting = '';
+        //Parsing the month part of the user defined formating
+        if ((calendarHeaderFormat.match(/Mo/g) || []).length > 0) {
+            monthFormatting = 'Mo';
+        } else {
+            if ((calendarHeaderFormat.match(/M/g) || []).length > 0) {
+                for (let i = (calendarHeaderFormat.match(/M/g) || []).length; i > 0; i--) {
+                    monthFormatting += 'M';
+                }
+            }
+        }
+
+        if (firstDay.month() === lastDay.month()) {
+            return firstDay.format(calendarHeaderFormat);
+        } else if (firstDay.year() !== lastDay.year()) {
+            return `${firstDay.format(calendarHeaderFormat)} / ${lastDay.format(calendarHeaderFormat)}`;
+        }
+
+        return `${monthFormatting.length > 1 ? firstDay.format(monthFormatting) : ''} ${monthFormatting.length > 1 ? '/' : ''} ${lastDay.format(calendarHeaderFormat)}`;
+
+    }
+
+
+    render() {
+        const headerText = this.formatCalendarHeader( this.props.datesForWeek, this.props.calendarHeaderFormat );
+        return (
+            <Text style={[styles.calendarHeader, this.props.calendarHeaderStyle]}>
+                {headerText}
+            </Text>
+        );
+    }
+}
+
+export default CalendarHeader;

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -11,6 +11,8 @@ import {
     Easing,
     TouchableOpacity
 } from 'react-native';
+
+import CalendarHeader from './CalendarHeader';
 import CalendarDay from './CalendarDay';
 import moment from 'moment';
 import styles from './Calendar.style.js';
@@ -119,7 +121,6 @@ export default class CalendarStrip extends Component {
         this.getNextWeek = this.getNextWeek.bind(this);
         this.onDateSelected = this.onDateSelected.bind(this);
         this.isDateSelected = this.isDateSelected.bind(this);
-        this.formatCalendarHeader = this.formatCalendarHeader.bind(this);
         this.animate = this.animate.bind(this);
         this.resetAnimation = this.resetAnimation.bind(this);
     }
@@ -400,35 +401,6 @@ export default class CalendarStrip extends Component {
         }
     }
 
-    //Function that formats the calendar header
-    //It also formats the month section if the week is in between months
-    formatCalendarHeader(datesForWeek) {
-        if (!datesForWeek || datesForWeek.length === 0) {
-            return;
-        }
-        let firstDay = datesForWeek[0];
-        let lastDay = datesForWeek[datesForWeek.length - 1];
-        let monthFormatting = '';
-        //Parsing the month part of the user defined formating
-        if ((this.props.calendarHeaderFormat.match(/Mo/g) || []).length > 0) {
-            monthFormatting = 'Mo';
-        } else {
-            if ((this.props.calendarHeaderFormat.match(/M/g) || []).length > 0) {
-                for (let i = (this.props.calendarHeaderFormat.match(/M/g) || []).length; i > 0; i--) {
-                    monthFormatting += 'M';
-                }
-            }
-        }
-
-        if (firstDay.month() === lastDay.month()) {
-            return firstDay.format(this.props.calendarHeaderFormat);
-        }
-        if (firstDay.year() !== lastDay.year()) {
-            return `${firstDay.format(this.props.calendarHeaderFormat)} / ${lastDay.format(this.props.calendarHeaderFormat)}`;
-        }
-        return `${monthFormatting.length > 1 ? firstDay.format(monthFormatting) : ''} ${monthFormatting.length > 1 ? '/' : ''} ${lastDay.format(this.props.calendarHeaderFormat)}`;
-    }
-
     render() {
         let datesForWeek = this.state.datesForWeek;
         let datesRender = [];
@@ -471,7 +443,13 @@ export default class CalendarStrip extends Component {
         let rightOpacity = {opacity: this.state.enableRightSelector ? 1 : 0};
         let leftSelector = this.props.leftSelector  || <Image style={[styles.icon, this.props.iconStyle, this.props.iconLeftStyle, leftOpacity]} source={this.props.iconLeft}/>;
         let rightSelector = this.props.rightSelector || <Image style={[styles.icon, this.props.iconStyle, this.props.iconRightStyle, rightOpacity]} source={this.props.iconRight}/>;
-        let calendarHeader = this.props.showMonth && <Text style={[styles.calendarHeader, this.props.calendarHeaderStyle]}>{this.formatCalendarHeader(datesForWeek)}</Text>;
+
+        let calendarHeader = <CalendarHeader
+            calendarHeaderFormat={this.props.calendarHeaderFormat}
+            calendarHeaderStyle={this.props.calendarHeaderStyle}
+            datesForWeek={this.state.datesForWeek}
+            startingDate={this.state.startingDate}
+        />;
 
         // calendarHeader renders above the dates & left/right selectors if dates are shown.
         // However if dates are hidden, the header shows between the left/right selectors.

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -444,7 +444,7 @@ export default class CalendarStrip extends Component {
         let leftSelector = this.props.leftSelector  || <Image style={[styles.icon, this.props.iconStyle, this.props.iconLeftStyle, leftOpacity]} source={this.props.iconLeft}/>;
         let rightSelector = this.props.rightSelector || <Image style={[styles.icon, this.props.iconStyle, this.props.iconRightStyle, rightOpacity]} source={this.props.iconRight}/>;
 
-        let calendarHeader = (
+        let calendarHeader = this.props.showMonth && (
             <CalendarHeader
                 calendarHeaderFormat={this.props.calendarHeaderFormat}
                 calendarHeaderStyle={this.props.calendarHeaderStyle}

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -444,12 +444,13 @@ export default class CalendarStrip extends Component {
         let leftSelector = this.props.leftSelector  || <Image style={[styles.icon, this.props.iconStyle, this.props.iconLeftStyle, leftOpacity]} source={this.props.iconLeft}/>;
         let rightSelector = this.props.rightSelector || <Image style={[styles.icon, this.props.iconStyle, this.props.iconRightStyle, rightOpacity]} source={this.props.iconRight}/>;
 
-        let calendarHeader = <CalendarHeader
-            calendarHeaderFormat={this.props.calendarHeaderFormat}
-            calendarHeaderStyle={this.props.calendarHeaderStyle}
-            datesForWeek={this.state.datesForWeek}
-            startingDate={this.state.startingDate}
-        />;
+        let calendarHeader = (
+            <CalendarHeader
+                calendarHeaderFormat={this.props.calendarHeaderFormat}
+                calendarHeaderStyle={this.props.calendarHeaderStyle}
+                datesForWeek={this.state.datesForWeek}
+            />
+        );
 
         // calendarHeader renders above the dates & left/right selectors if dates are shown.
         // However if dates are hidden, the header shows between the left/right selectors.


### PR DESCRIPTION
Created a new CalendarHeader Component in an attempt to simplify the code a little bit.  This new component only uses props and no state. 

I've also added a shouldComponentUpdate function to the CalendarHeader to prevent the recalculation of the header when it isn't required.  I just used JSON.stringify for comparison here as I wasn't sure whether to add external libraries to do this (eg lodash or deep-equal or whatever). 