### PR TITLE
Extract WeekSelector component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage
+jsconfig.jsconfig
 
 # OSX
 #

--- a/__tests__/WeekSelector.js
+++ b/__tests__/WeekSelector.js
@@ -1,0 +1,229 @@
+import React from 'react';
+import { Image, Text } from 'react-native';
+
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import WeekSelector from '../src/WeekSelector';
+import defaultStyles from '../src/Calendar.style.js';
+
+import moment from 'moment';
+import _ from 'lodash';
+
+const genDatesForWeek = startDate => {
+    const day = moment(startDate);
+    return _.map(_.range(7), i => day.clone().add(i, 'days'));
+};
+
+describe('WeekSelector Component', () => {
+    it('should render without issues', () => {
+        const component = shallow(
+            <WeekSelector imageSource={require('./img/left-arrow-black.png')} />
+        );
+
+        expect(component.length).toBe(1);
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should have onPress event', () => {
+        const onPress = jest.fn();
+        const component = shallow(
+            <WeekSelector
+                imageSource={require('./img/left-arrow-black.png')}
+                onPress={onPress}
+            />
+        );
+
+        component.simulate('press');
+        expect(onPress).toHaveBeenCalled();
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should have the default container style', () => {
+        const component = shallow(
+            <WeekSelector imageSource={require('./img/left-arrow-black.png')} />
+        );
+
+        const styles = component.props().style;
+
+        expect(_.filter(styles)).toHaveLength(1);
+        expect(styles[0]).toEqual(defaultStyles.iconContainer);
+    });
+
+    it('should have a custom container style of color red', () => {
+        const component = shallow(
+            <WeekSelector
+                iconContainerStyle={{ color: 'red' }}
+                imageSource={require('./img/left-arrow-black.png')}
+            />
+        );
+
+        const styles = component.props().style;
+
+        expect(_.filter(styles)).toHaveLength(2);
+        expect(styles[styles.length - 1].color).toBe('red');
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should be enabled', () => {
+        const datesForWeek = genDatesForWeek('2018-01-10');
+
+        const component = shallow(
+            <WeekSelector
+                imageSource={require('./img/left-arrow-black.png')}
+                controlDate={moment('2018-01-08')}
+                weekEndDate={datesForWeek[datesForWeek.length - 1]}
+                weekStartDate={datesForWeek[0]}
+            />
+        );
+        expect(component.props().disabled).toBe(false);
+    });
+
+    it('should be disabled', () => {
+        const datesForWeek = genDatesForWeek('2018-01-10');
+
+        const component = shallow(
+            <WeekSelector
+                imageSource={require('./img/left-arrow-black.png')}
+                controlDate={moment('2018-01-12')}
+                weekEndDate={datesForWeek[datesForWeek.length - 1]}
+                weekStartDate={datesForWeek[0]}
+            />
+        );
+        expect(component.props().disabled).toBe(true);
+        expect(toJson(component)).toMatchSnapshot();
+    });
+});
+
+describe('WeekSelector Image Component ', () => {
+    it('should have render an image', () => {
+        const component = shallow(
+            <WeekSelector imageSource={require('./img/left-arrow-black.png')} />
+        );
+
+        const imageComponent = component.find(Image);
+        expect(imageComponent).toHaveLength(1);
+    });
+
+    it('should show the default styles', () => {
+        const component = shallow(
+            <WeekSelector imageSource={require('./img/left-arrow-black.png')} />
+        );
+
+        const imageComponent = component.find(Image);
+        const styles = imageComponent.props().style;
+
+        // REM the opacity is applied by default
+        expect(_.filter(styles)).toHaveLength(2);
+        expect(styles[0]).toEqual(defaultStyles.icon);
+    });
+
+    it('should have custom icon style of backgroundColor red', () => {
+        const component = shallow(
+            <WeekSelector
+                iconStyle={{ backgroundColor: 'red' }}
+                imageSource={require('./img/left-arrow-black.png')}
+            />
+        );
+
+        const imageComponent = component.find(Image);
+        const styles = imageComponent.props().style;
+        const finalStyle = _.findLast(styles, 'backgroundColor');
+
+        // REM the opacity is applied by default
+        expect(_.filter(styles)).toHaveLength(3);
+        expect(finalStyle).not.toBeNull();
+        expect(finalStyle.backgroundColor).toEqual('red');
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should have custom icon instance style of backgroundColor blue', () => {
+        const component = shallow(
+            <WeekSelector
+                iconStyle={{ backgroundColor: 'red' }}
+                iconInstanceStyle={{ backgroundColor: 'blue' }}
+                imageSource={require('./img/left-arrow-black.png')}
+            />
+        );
+
+        const imageComponent = component.find(Image);
+        const styles = imageComponent.props().style;
+        const finalStyle = _.findLast(styles, 'backgroundColor');
+
+        // REM the opacity is applied by default
+        expect(_.filter(styles)).toHaveLength(4);
+        expect(finalStyle).not.toBeNull();
+        expect(finalStyle.backgroundColor).toEqual('blue');
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should be enabled with opacity 1', () => {
+        const datesForWeek = genDatesForWeek('2018-01-10');
+
+        const component = shallow(
+            <WeekSelector
+                imageSource={require('./img/left-arrow-black.png')}
+                controlDate={moment('2018-01-08')}
+                weekEndDate={datesForWeek[datesForWeek.length - 1]}
+                weekStartDate={datesForWeek[0]}
+            />
+        );
+
+        const imageComponent = component.find(Image);
+        const styles = imageComponent.props().style;
+        const finalStyle = _.findLast(styles, 'opacity');
+
+        expect(finalStyle).not.toBeNull();
+        expect(finalStyle.opacity).toBe(1);
+    });
+
+    it('should be disabled with opacity 0', () => {
+        const datesForWeek = genDatesForWeek('2018-01-10');
+
+        const component = shallow(
+            <WeekSelector
+                imageSource={require('./img/left-arrow-black.png')}
+                controlDate={moment('2018-01-12')}
+                weekEndDate={datesForWeek[datesForWeek.length - 1]}
+                weekStartDate={datesForWeek[0]}
+            />
+        );
+        const imageComponent = component.find(Image);
+        const styles = imageComponent.props().style;
+        const finalStyle = _.findLast(styles, ['opacity', 0]);
+
+        expect(finalStyle).not.toBeNull();
+        expect(finalStyle.opacity).toBe(0);
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should render a custom component', () => {
+        const component = shallow(
+            <WeekSelector iconComponent={<Text>GO BACK</Text>} />
+        );
+
+        const customComponent = component.find(Text);
+        expect(customComponent).toHaveLength(1);
+        expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('should render a custom component that is disabled', () => {
+        const datesForWeek = genDatesForWeek('2018-01-10');
+
+        const component = shallow(
+            <WeekSelector
+                iconComponent={<Text style={{ color: 'red' }}>GO BACK</Text>}
+                controlDate={moment('2018-01-12')}
+                weekEndDate={datesForWeek[datesForWeek.length - 1]}
+                weekStartDate={datesForWeek[0]}
+            />
+        );
+
+        const customComponent = component.find(Text);
+        const styles = customComponent.props().style;
+        const finalStyle = _.findLast(styles, ['opacity', 0]);
+
+        expect(finalStyle).not.toBeNull();
+        expect(finalStyle.opacity).toBe(0);
+        expect(toJson(component)).toMatchSnapshot();
+    });
+});

--- a/__tests__/__snapshots__/WeekSelector.js.snap
+++ b/__tests__/__snapshots__/WeekSelector.js.snap
@@ -1,0 +1,323 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WeekSelector Component should be disabled 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={true}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        undefined,
+        undefined,
+        Object {
+          "opacity": 0,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Component should have a custom container style of color red 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      Object {
+        "color": "red",
+      },
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        undefined,
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Component should have onPress event 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        undefined,
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Component should render without issues 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        undefined,
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Image Component  should be disabled with opacity 0 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={true}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        undefined,
+        undefined,
+        Object {
+          "opacity": 0,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Image Component  should have custom icon instance style of backgroundColor blue 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        Object {
+          "backgroundColor": "red",
+        },
+        Object {
+          "backgroundColor": "blue",
+        },
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Image Component  should have custom icon style of backgroundColor red 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    source={1}
+    style={
+      Array [
+        Object {
+          "height": 20,
+          "resizeMode": "contain",
+          "width": 20,
+        },
+        Object {
+          "backgroundColor": "red",
+        },
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  />
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Image Component  should render a custom component 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={false}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  >
+    GO BACK
+  </Text>
+</TouchableOpacity>
+`;
+
+exports[`WeekSelector Image Component  should render a custom component that is disabled 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  disabled={true}
+  focusedOpacity={0.7}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "red",
+        },
+        Object {
+          "opacity": 0,
+        },
+      ]
+    }
+  >
+    GO BACK
+  </Text>
+</TouchableOpacity>
+`;

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -4,16 +4,14 @@
 
 import React, {Component} from 'react';
 import {
-    Text,
     View,
-    Image,
     Animated,
-    Easing,
-    TouchableOpacity
+    Easing
 } from 'react-native';
 
 import CalendarHeader from './CalendarHeader';
 import CalendarDay from './CalendarDay';
+import WeekSelector from './WeekSelector';
 import moment from 'moment';
 import styles from './Calendar.style.js';
 
@@ -107,9 +105,7 @@ export default class CalendarStrip extends Component {
             datesAllowedForWeek: [],
             datesSelectedForWeek: [],
             datesCustomStylesForWeek: [],
-            selectedDate,
-            enableLeftSelector: true,
-            enableRightSelector: true,
+            selectedDate
         };
 
         this.resetAnimation();
@@ -235,16 +231,7 @@ export default class CalendarStrip extends Component {
       startingDate[addOrSubtract](adjustWeeks, 'w');
 
       let newState = {startingDate};
-      let endOfWeekDate;
-      if (props.minDate || props.maxDate) {
-        endOfWeekDate = startingDate.clone().add(6, 'days');
-      }
-      if (props.minDate) {
-        newState.enableLeftSelector = !moment(props.minDate).isBetween(startingDate, endOfWeekDate, 'day', '[]');
-      }
-      if (props.maxDate) {
-        newState.enableRightSelector = !moment(props.maxDate).isBetween(startingDate, endOfWeekDate, 'day', '[]');
-      }
+
       this.setState(newState);
       return startingDate;
     }
@@ -439,10 +426,6 @@ export default class CalendarStrip extends Component {
             </View>
           );
         }
-        let leftOpacity = {opacity: this.state.enableLeftSelector ? 1 : 0};
-        let rightOpacity = {opacity: this.state.enableRightSelector ? 1 : 0};
-        let leftSelector = this.props.leftSelector  || <Image style={[styles.icon, this.props.iconStyle, this.props.iconLeftStyle, leftOpacity]} source={this.props.iconLeft}/>;
-        let rightSelector = this.props.rightSelector || <Image style={[styles.icon, this.props.iconStyle, this.props.iconRightStyle, rightOpacity]} source={this.props.iconRight}/>;
 
         let calendarHeader = this.props.showMonth && (
             <CalendarHeader
@@ -458,13 +441,19 @@ export default class CalendarStrip extends Component {
             <View style={[styles.calendarContainer, {backgroundColor: this.props.calendarColor}, this.props.style]}>
                 { this.props.showDate && calendarHeader }
                 <View style={styles.datesStrip}>
-                    <TouchableOpacity
-                      style={[styles.iconContainer, this.props.iconContainer]}
-                      onPress={this.getPreviousWeek}
-                      disabled={!this.state.enableLeftSelector}
-                    >
-                      { leftSelector }
-                    </TouchableOpacity>
+
+                    <WeekSelector
+                        controlDate={this.props.minDate}
+                        iconComponent={this.props.leftSelector}
+                        iconContainerStyle={this.props.iconContainer}
+                        iconInstanceStyle={this.props.iconLeftStyle}
+                        iconStyle={this.props.iconStyle}
+                        imageSource={this.props.iconLeft}
+                        onPress={this.getPreviousWeek}
+                        weekEndDate={this.state.datesForWeek[this.state.datesForWeek.length - 1]}
+                        weekStartDate={this.state.datesForWeek[0]}
+                    />
+
                     { this.props.showDate ?
                       <View style={styles.calendarDates}>
                           {datesRender}
@@ -472,13 +461,19 @@ export default class CalendarStrip extends Component {
                       :
                       calendarHeader
                     }
-                    <TouchableOpacity
-                      style={[styles.iconContainer, this.props.iconContainer]}
-                      onPress={this.getNextWeek}
-                      disabled={!this.state.enableRightSelector}
-                    >
-                      { rightSelector }
-                    </TouchableOpacity>
+
+                    <WeekSelector
+                        controlDate={this.props.maxDate}
+                        iconComponent={this.props.rightSelector}
+                        iconContainerStyle={this.props.iconContainer}
+                        iconInstanceStyle={this.props.iconRightStyle}
+                        iconStyle={this.props.iconStyle}
+                        imageSource={this.props.iconRight}
+                        onPress={this.getNextWeek}
+                        weekEndDate={this.state.datesForWeek[this.state.datesForWeek.length - 1]}
+                        weekStartDate={this.state.datesForWeek[0]}
+                    />
+
               </View>
             </View>
         );

--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import { Image, TouchableOpacity } from 'react-native';
+
+import moment from 'moment';
+
+import styles from './Calendar.style.js';
+
+class WeekSelector extends Component {
+    static propTypes = {
+        controlDate: React.PropTypes.object,
+        iconComponent: React.PropTypes.any,
+        iconContainerStyle: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number
+        ]),
+        iconInstanceStyle: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number
+        ]),
+        iconStyle: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number
+        ]),
+        imageSource: React.PropTypes.number,
+        onPress: React.PropTypes.func,
+        weekStartDate: React.PropTypes.object,
+        weekEndDate: React.PropTypes.object
+    };
+
+    shouldComponentUpdate(nextProps) {
+        return JSON.stringify(this.props) !== JSON.stringify(nextProps);
+    }
+
+    isEnabled(controlDate, weekStartDate, weekEndDate) {
+        if (controlDate) {
+            return !moment(controlDate).isBetween(
+                weekStartDate,
+                weekEndDate,
+                'day',
+                '[]'
+            );
+        }
+        return true;
+    }
+
+    render() {
+        const {
+            controlDate,
+            iconContainerStyle,
+            iconComponent,
+            iconInstanceStyle,
+            iconStyle,
+            imageSource,
+            onPress,
+            weekEndDate,
+            weekStartDate
+        } = this.props;
+
+        const enabled = this.isEnabled(controlDate, weekStartDate, weekEndDate);
+        const opacity = { opacity: enabled ? 1 : 0 };
+
+        let component;
+        if (iconComponent) {
+            component = React.cloneElement(iconComponent, {
+                style: [ iconComponent.props.style, { opacity: opacity.opacity } ]
+            });
+        } else {
+            component = (
+                <Image
+                    style={[styles.icon, iconStyle, iconInstanceStyle, opacity]}
+                    source={imageSource}
+                />
+            );
+        }
+
+        return (
+            <TouchableOpacity
+                style={[styles.iconContainer, iconContainerStyle]}
+                onPress={onPress}
+                disabled={!enabled}
+            >
+                {component}
+            </TouchableOpacity>
+        );
+    }
+}
+
+export default WeekSelector;

--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -21,7 +21,10 @@ class WeekSelector extends Component {
             React.PropTypes.object,
             React.PropTypes.number
         ]),
-        imageSource: React.PropTypes.number,
+        imageSource: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number
+        ]),
         onPress: React.PropTypes.func,
         weekStartDate: React.PropTypes.object,
         weekEndDate: React.PropTypes.object


### PR DESCRIPTION
This extracts a new WeekSelector component from the main CalendarStrip Component.  The new component uses no state and works with the passed in props.  

Tests are included and bug fix applied where the opacity wasn't being assigned if a custom leftSelector or rightSelector was being used.  

More importantly, this removes some state and functionality from the CalendarStrip into the new component, especially the UpdateView function.