### PR TITLE
Use transparent background for days that aren't selected

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -111,7 +111,7 @@ export default class CalendarDay extends Component {
           //If it is border, the user has to input color for border animation
           switch (this.props.daySelectionAnimation.type) {
             case 'background':
-              let dateViewBGColor = this.state.selected ? this.props.daySelectionAnimation.highlightColor : this.props.calendarColor;
+              let dateViewBGColor = this.state.selected ? this.props.daySelectionAnimation.highlightColor : 'transparent';
               dateViewStyle = {backgroundColor: dateViewBGColor};
               break;
             case 'border':


### PR DESCRIPTION
Fix for #22 

Using transparent background fixes problem with layout where days would overlap and circle of the selected day would get cut out.