### PR TITLE
ability to override the underlying text element allowFontScaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Methods may be accessed through the instantiated component's [ref](https://react
 | **`disabledDateNumberStyle`**  | Style for disabled number of the day in dates strip (controlled by datesWhitelist & datesBlacklist).                                                                                                                                                                                     | Any    |
 | **`disabledDateOpacity`**      | Opacity of disabled dates strip.                                                                                                                                                                                                                                                         | Number | **`0.3`**  |
 | **`customDatesStyles`**        | Custom per-date styling, overriding the styles above. Check Table <a href="#customdatesstyles"> Below </a>                                                                                                                                                                               | Array  |
+| **`shouldAllowFontScaling`**   | Override the underlying Text element scaling to respect font settings                                                                                                                                                                            | Bool   | **`False`**|
 
 #### Responsive Sizing
 

--- a/example/example/App.js
+++ b/example/example/App.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Component } from 'react';
-import CalendarStrip from 'react-native-calendar-strip';
+import CalendarStrip from "react-native-calendar-strip";
 
 export default class App extends Component<{}> {
   render() {

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -32,7 +32,8 @@ export default class CalendarDay extends Component {
     styleWeekend: PropTypes.bool,
     customStyle: PropTypes.object,
 
-    daySelectionAnimation: PropTypes.object
+    daySelectionAnimation: PropTypes.object,
+    allowDayTextScaling: PropTypes.bool
   };
 
   // Reference: https://medium.com/@Jpoliachik/react-native-s-layoutanimation-is-awesome-4a4d317afd3e
@@ -208,6 +209,7 @@ export default class CalendarDay extends Component {
           {this.props.showDayName && (
             <Text
               style={[dateNameStyle, { fontSize: this.state.dateNameFontSize }]}
+              allowFontScaling={(this.props.allowDayTextScaling !== undefined ? this.props.allowDayTextScaling : false)}
             >
               {this.props.date.format("ddd").toUpperCase()}
             </Text>
@@ -218,6 +220,7 @@ export default class CalendarDay extends Component {
                 dateNumberStyle,
                 { fontSize: this.state.dateNumberFontSize }
               ]}
+              allowFontScaling={(this.props.allowDayTextScaling !== undefined ? this.props.allowDayTextScaling : false)}
             >
               {this.props.date.date()}
             </Text>

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -209,7 +209,7 @@ export default class CalendarDay extends Component {
           {this.props.showDayName && (
             <Text
               style={[dateNameStyle, { fontSize: this.state.dateNameFontSize }]}
-              allowFontScaling={(this.props.allowDayTextScaling !== undefined ? this.props.allowDayTextScaling : false)}
+              allowFontScaling={this.props.allowDayTextScaling}
             >
               {this.props.date.format("ddd").toUpperCase()}
             </Text>
@@ -220,7 +220,7 @@ export default class CalendarDay extends Component {
                 dateNumberStyle,
                 { fontSize: this.state.dateNumberFontSize }
               ]}
-              allowFontScaling={(this.props.allowDayTextScaling !== undefined ? this.props.allowDayTextScaling : false)}
+              allowFontScaling={this.props.allowDayTextScaling}
             >
               {this.props.date.date()}
             </Text>

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -72,7 +72,7 @@ class CalendarHeader extends Component {
           { fontSize: this.props.fontSize },
           this.props.calendarHeaderStyle
         ]}
-        allowFontScaling={(this.props.allowHeaderTextScaling !== undefined ? this.props.allowHeaderTextScaling : false)}
+        allowFontScaling={this.props.allowHeaderTextScaling}
       >
         {headerText}
       </Text>

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -11,7 +11,8 @@ class CalendarHeader extends Component {
       PropTypes.object,
       PropTypes.number
     ]),
-    datesForWeek: PropTypes.array.isRequired
+    datesForWeek: PropTypes.array.isRequired,
+    allowHeaderTextScaling: PropTypes.bool
   };
 
   shouldComponentUpdate(nextProps) {
@@ -63,6 +64,7 @@ class CalendarHeader extends Component {
       this.props.datesForWeek,
       this.props.calendarHeaderFormat
     );
+    console.log('this.props', this.props);
     return (
       <Text
         style={[
@@ -70,6 +72,7 @@ class CalendarHeader extends Component {
           { fontSize: this.props.fontSize },
           this.props.calendarHeaderStyle
         ]}
+        allowFontScaling={(this.props.allowHeaderTextScaling !== undefined ? this.props.allowHeaderTextScaling : false)}
       >
         {headerText}
       </Text>

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -90,7 +90,8 @@ export default class CalendarStrip extends Component {
     responsiveSizingOffset: 0,
     innerStyle: { flex: 1 },
     maxDayComponentSize: 80,
-    minDayComponentSize: 10
+    minDayComponentSize: 10,
+    shouldAllowFontScaling: false
   };
 
   constructor(props) {

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -91,7 +91,7 @@ export default class CalendarStrip extends Component {
     innerStyle: { flex: 1 },
     maxDayComponentSize: 80,
     minDayComponentSize: 10,
-    shouldAllowFontScaling: false
+    shouldAllowFontScaling: true
   };
 
   constructor(props) {

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -71,7 +71,8 @@ export default class CalendarStrip extends Component {
     disabledDateOpacity: PropTypes.number,
     styleWeekend: PropTypes.bool,
 
-    locale: PropTypes.object
+    locale: PropTypes.object,
+    shouldAllowFontScaling: PropTypes.bool
   };
 
   static defaultProps = {
@@ -545,6 +546,7 @@ export default class CalendarStrip extends Component {
           daySelectionAnimation={this.props.daySelectionAnimation}
           customStyle={this.state.datesCustomStylesForWeek[i]}
           size={this.state.dayComponentWidth}
+          allowDayTextScaling={this.props.shouldAllowFontScaling}
         />
       );
       datesRender.push(
@@ -569,6 +571,7 @@ export default class CalendarStrip extends Component {
         calendarHeaderStyle={this.props.calendarHeaderStyle}
         datesForWeek={this.state.datesForWeek}
         fontSize={this.state.monthFontSize}
+        allowHeaderTextScaling={this.props.shouldAllowFontScaling}
       />
     );
 


### PR DESCRIPTION
This should solve the problem whereby the styling of the component breaks when the user sets large fonts on their phones. Specifically on iOS