### PR TITLE
Ability to set default Date container styles

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -55,6 +55,7 @@ class CalendarDay extends Component {
       animProperty: LayoutAnimation.Properties.opacity,
       animSpringDamping: undefined // Only applicable for LayoutAnimation.Types.spring,
     },
+    disabledDateContainerStyle: [],
     styleWeekend: true,
     showDayName: true,
     showDayNumber: true
@@ -137,7 +138,7 @@ class CalendarDay extends Component {
       !this.props.enabled && this.props.disabledDateNumberStyle
     ];
     let dateViewStyle = this.props.enabled
-      ? [{ backgroundColor: "transparent" }]
+      ? [{ backgroundColor: "transparent" }, this.props.dateContainerStyle]
       : [
           this.props.disabledDateContainerStyle.push({
             opacity: this.props.disabledDateOpacity
@@ -174,7 +175,6 @@ class CalendarDay extends Component {
 
       dateNameStyle = [styles.dateName, this.props.dateNameStyle];
       dateNumberStyle = [styles.dateNumber, this.props.dateNumberStyle];
-      dateViewStyle = [styles.dateNumber, this.props.dateContainerStyle];
       if (
         this.props.styleWeekend &&
         (this.props.date.isoWeekday() === 6 ||
@@ -188,10 +188,7 @@ class CalendarDay extends Component {
           styles.weekendDateNumber,
           this.props.weekendDateNumberStyle
         ];
-        dateViewStyle = [
-          styles.weekendDateNumber,
-          this.props.weekendDateContainerStyle
-        ];
+        dateViewStyle.push(this.props.weekendDateContainerStyle);
       }
       if (this.state.selected) {
         dateNameStyle = [styles.dateName, this.props.highlightDateNameStyle];
@@ -199,10 +196,7 @@ class CalendarDay extends Component {
           styles.dateNumber,
           this.props.highlightDateNumberStyle
         ];
-        dateViewStyle = [
-          styles.dateViewStyle,
-          this.props.highlightDateContainerStyle
-        ];
+        dateViewStyle.push(this.props.highlightDateContainerStyle);
       }
     }
 

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import {polyfill} from 'react-lifecycles-compat';
+import { polyfill } from "react-lifecycles-compat";
 
 import { Text, View, LayoutAnimation, TouchableOpacity } from "react-native";
 import styles from "./Calendar.style.js";
@@ -23,15 +23,19 @@ class CalendarDay extends Component {
 
     dateNameStyle: PropTypes.any,
     dateNumberStyle: PropTypes.any,
+    dateContainerStyle: PropTypes.any,
     weekendDateNameStyle: PropTypes.any,
     weekendDateNumberStyle: PropTypes.any,
     highlightDateNameStyle: PropTypes.any,
     highlightDateNumberStyle: PropTypes.any,
+    highlightDateContainerStyle: PropTypes.any,
     disabledDateNameStyle: PropTypes.any,
     disabledDateNumberStyle: PropTypes.any,
+    disabledDateContainerStyle: PropTypes.any,
     disabledDateOpacity: PropTypes.number,
     styleWeekend: PropTypes.bool,
     customStyle: PropTypes.object,
+    size: PropTypes.any,
 
     daySelectionAnimation: PropTypes.object,
     allowDayTextScaling: PropTypes.bool
@@ -65,7 +69,7 @@ class CalendarDay extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    newState = {};
+    let newState = {};
     let doStateUpdate = false;
 
     if (this.props.selected !== prevProps.selected) {
@@ -123,11 +127,21 @@ class CalendarDay extends Component {
 
   render() {
     // Defaults for disabled state
-    let dateNameStyle = [styles.dateName, !this.props.enabled && this.props.disabledDateNameStyle];
-    let dateNumberStyle = [styles.dateNumber, !this.props.enabled && this.props.disabledDateNumberStyle];
+    let dateNameStyle = [
+      styles.dateName,
+      !this.props.enabled && this.props.disabledDateNameStyle
+    ];
+    let dateNumberStyle = [
+      styles.dateNumber,
+      !this.props.enabled && this.props.disabledDateNumberStyle
+    ];
     let dateViewStyle = this.props.enabled
       ? [{ backgroundColor: "transparent" }]
-      : [{ opacity: this.props.disabledDateOpacity }];
+      : [
+          this.props.disabledDateContainerStyle.push({
+            opacity: this.props.disabledDateOpacity
+          })
+        ];
 
     let customStyle = this.props.customStyle;
     if (customStyle) {
@@ -142,7 +156,9 @@ class CalendarDay extends Component {
       //If it is border, the user has to input color for border animation
       switch (this.props.daySelectionAnimation.type) {
         case "background":
-          dateViewStyle.push({ backgroundColor: this.props.daySelectionAnimation.highlightColor });
+          dateViewStyle.push({
+            backgroundColor: this.props.daySelectionAnimation.highlightColor
+          });
           break;
         case "border":
           dateViewStyle.push({
@@ -157,6 +173,7 @@ class CalendarDay extends Component {
 
       dateNameStyle = [styles.dateName, this.props.dateNameStyle];
       dateNumberStyle = [styles.dateNumber, this.props.dateNumberStyle];
+      dateViewStyle = [styles.dateNumber, this.props.dateContainerStyle];
       if (
         this.props.styleWeekend &&
         (this.props.date.isoWeekday() === 6 ||
@@ -176,6 +193,10 @@ class CalendarDay extends Component {
         dateNumberStyle = [
           styles.dateNumber,
           this.props.highlightDateNumberStyle
+        ];
+        dateViewStyle = [
+          styles.dateViewStyle,
+          this.props.highlightDateContainerStyle
         ];
       }
     }

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -26,6 +26,7 @@ class CalendarDay extends Component {
     dateContainerStyle: PropTypes.any,
     weekendDateNameStyle: PropTypes.any,
     weekendDateNumberStyle: PropTypes.any,
+    weekendDateContainerStyle: PropTypes.any,
     highlightDateNameStyle: PropTypes.any,
     highlightDateNumberStyle: PropTypes.any,
     highlightDateContainerStyle: PropTypes.any,
@@ -186,6 +187,10 @@ class CalendarDay extends Component {
         dateNumberStyle = [
           styles.weekendDateNumber,
           this.props.weekendDateNumberStyle
+        ];
+        dateViewStyle = [
+          styles.weekendDateNumber,
+          this.props.weekendDateContainerStyle
         ];
       }
       if (this.state.selected) {

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -66,6 +66,7 @@ class CalendarStrip extends Component {
     dateContainerStyle: PropTypes.any,
     weekendDateNameStyle: PropTypes.any,
     weekendDateNumberStyle: PropTypes.any,
+    weekendDateContainerStyle: PropTypes.any,
     highlightDateNameStyle: PropTypes.any,
     highlightDateNumberStyle: PropTypes.any,
     highlightDateContainerStyle: PropTypes.any,
@@ -541,6 +542,7 @@ class CalendarStrip extends Component {
           dateContainerStyle={this.props.dateContainerStyle}
           weekendDateNameStyle={this.props.weekendDateNameStyle}
           weekendDateNumberStyle={this.props.weekendDateNumberStyle}
+          weekendDateContainerStyle={this.props.weekendDateContainerStyle}
           highlightDateNameStyle={this.props.highlightDateNameStyle}
           highlightDateNumberStyle={this.props.highlightDateNumberStyle}
           highlightDateContainerStyle={this.props.highlightDateContainerStyle}

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import {polyfill} from 'react-lifecycles-compat';
+import { polyfill } from "react-lifecycles-compat";
 import { View, Animated, Easing } from "react-native";
 
 import moment from "moment";
@@ -173,7 +173,9 @@ class CalendarStrip extends Component {
       !this.compareDates(prevProps.startingDate, this.props.startingDate)
     ) {
       updateState = true;
-      startingDate = { startingDate: this.setLocale(moment(this.props.startingDate))};
+      startingDate = {
+        startingDate: this.setLocale(moment(this.props.startingDate))
+      };
       weekData = this.updateWeekData(
         startingDate.startingDate,
         this.state.selectedDate,

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -63,12 +63,15 @@ class CalendarStrip extends Component {
 
     dateNameStyle: PropTypes.any,
     dateNumberStyle: PropTypes.any,
+    dateContainerStyle: PropTypes.any,
     weekendDateNameStyle: PropTypes.any,
     weekendDateNumberStyle: PropTypes.any,
     highlightDateNameStyle: PropTypes.any,
     highlightDateNumberStyle: PropTypes.any,
+    highlightDateContainerStyle: PropTypes.any,
     disabledDateNameStyle: PropTypes.any,
     disabledDateNumberStyle: PropTypes.any,
+    disabledDateContainerStyle: PropTypes.any,
     disabledDateOpacity: PropTypes.number,
     styleWeekend: PropTypes.bool,
 
@@ -535,12 +538,15 @@ class CalendarStrip extends Component {
           calendarColor={this.props.calendarColor}
           dateNameStyle={this.props.dateNameStyle}
           dateNumberStyle={this.props.dateNumberStyle}
+          dateContainerStyle={this.props.dateContainerStyle}
           weekendDateNameStyle={this.props.weekendDateNameStyle}
           weekendDateNumberStyle={this.props.weekendDateNumberStyle}
           highlightDateNameStyle={this.props.highlightDateNameStyle}
           highlightDateNumberStyle={this.props.highlightDateNumberStyle}
+          highlightDateContainerStyle={this.props.highlightDateContainerStyle}
           disabledDateNameStyle={this.props.disabledDateNameStyle}
           disabledDateNumberStyle={this.props.disabledDateNumberStyle}
+          disabledDateContainerStyle={this.props.disabledDateContainerStyle}
           disabledDateOpacity={this.props.disabledDateOpacity}
           styleWeekend={this.props.styleWeekend}
           daySelectionAnimation={this.props.daySelectionAnimation}


### PR DESCRIPTION
Didn't want to use custom styles per day, so I added ability to pass in default container styles

example
![image](https://user-images.githubusercontent.com/5123871/42296379-dbf6f694-7fba-11e8-87cc-d80b85e6e1f1.png)
