### PR TITLE
Issue was: Custom Size wouldn't apply. [Fixed]

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -210,8 +210,8 @@ class CalendarDay extends Component {
           {this.props.showDayNumber && (
             <Text
               style={[
-                dateNumberStyle,
-                { fontSize: this.state.dateNumberFontSize }
+                  { fontSize: this.state.dateNumberFontSize },
+                  dateNumberStyle
               ]}
               allowFontScaling={this.props.allowDayTextScaling}
             >


### PR DESCRIPTION
dateNumberFontSize was replaced by the calculated size inside CalendarDay. Now that defautl size would applied if user doesn't pass any size and if user passes size property it will be applied

issue https://github.com/BugiDev/react-native-calendar-strip/issues/86