### PR TITLE
add ability to keep font size for day number and day text, also be able to set header format.

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -119,7 +119,7 @@ class CalendarDay extends Component {
       containerPadding: Math.round(props.size / 5),
       containerBorderRadius: Math.round(props.size / 2),
       dateNameFontSize: Math.round(props.size / 5),
-      dateNumberFontSize: Math.round(props.size / 2.3)
+      dateNumberFontSize: Math.round(props.size / 2.9)
     };
   }
 

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -117,7 +117,7 @@ class CalendarDay extends Component {
       containerPadding: Math.round(props.size / 5),
       containerBorderRadius: Math.round(props.size / 2),
       dateNameFontSize: Math.round(props.size / 5),
-      dateNumberFontSize: Math.round(props.size / 2.9)
+      dateNumberFontSize: Math.round(props.size / 2.3)
     };
   }
 

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import {polyfill} from 'react-lifecycles-compat';
+import { polyfill } from 'react-lifecycles-compat';
 
 import { Text, View, LayoutAnimation, TouchableOpacity } from "react-native";
 import styles from "./Calendar.style.js";
@@ -34,7 +34,9 @@ class CalendarDay extends Component {
     customStyle: PropTypes.object,
 
     daySelectionAnimation: PropTypes.object,
-    allowDayTextScaling: PropTypes.bool
+    allowDayTextScaling: PropTypes.bool,
+    keepDayNumberFontSize: PropTypes.bool,
+    keepDayNameFontSize: PropTypes.bool
   };
 
   // Reference: https://medium.com/@Jpoliachik/react-native-s-layoutanimation-is-awesome-4a4d317afd3e
@@ -201,7 +203,7 @@ class CalendarDay extends Component {
         >
           {this.props.showDayName && (
             <Text
-              style={[dateNameStyle, { fontSize: this.state.dateNameFontSize }]}
+              style={[dateNameStyle, !this.props.keepDayNameFontSize && { fontSize: this.state.dateNameFontSize }]}
               allowFontScaling={this.props.allowDayTextScaling}
             >
               {this.props.date.format("ddd").toUpperCase()}
@@ -210,8 +212,8 @@ class CalendarDay extends Component {
           {this.props.showDayNumber && (
             <Text
               style={[
-                  { fontSize: this.state.dateNumberFontSize },
-                  dateNumberStyle
+                !this.props.keepDayNumberFontSize && { fontSize: this.state.dateNumberFontSize },
+                dateNumberStyle
               ]}
               allowFontScaling={this.props.allowDayTextScaling}
             >

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -212,8 +212,8 @@ class CalendarDay extends Component {
           {this.props.showDayNumber && (
             <Text
               style={[
-                !this.props.keepDayNumberFontSize && { fontSize: this.state.dateNumberFontSize },
-                dateNumberStyle
+                dateNumberStyle,
+                !this.props.keepDayNumberFontSize && { fontSize: this.state.dateNumberFontSize }
               ]}
               allowFontScaling={this.props.allowDayTextScaling}
             >

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -43,13 +43,14 @@ class CalendarHeader extends Component {
         }
       }
     }
-
+    
     if (firstDay.month() === lastDay.month()) {
-      return firstDay.format(calendarHeaderFormat);
+      return lastDay.format(calendarHeaderFormat);
     } else if (firstDay.year() !== lastDay.year()) {
-      return `${firstDay.format(calendarHeaderFormat)} / ${lastDay.format(
-        calendarHeaderFormat
-      )}`;
+//       return `${firstDay.format(calendarHeaderFormat)} / ${lastDay.format(
+//         calendarHeaderFormat
+//       )}`;
+      return lastDay.format(calendarHeaderFormat);
     }
 
     return `${

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -43,21 +43,22 @@ class CalendarHeader extends Component {
         }
       }
     }
-    
-    if (firstDay.month() === lastDay.month()) {
-      return lastDay.format(calendarHeaderFormat);
-    } else if (firstDay.year() !== lastDay.year()) {
-//       return `${firstDay.format(calendarHeaderFormat)} / ${lastDay.format(
-//         calendarHeaderFormat
-//       )}`;
-      return lastDay.format(calendarHeaderFormat);
-    }
 
-    return `${
-      monthFormatting.length > 1 ? firstDay.format(monthFormatting) : ""
-    } ${monthFormatting.length > 1 ? "/" : ""} ${lastDay.format(
-      calendarHeaderFormat
-    )}`;
+    return lastDay.format(calendarHeaderFormat);
+    
+    // if (firstDay.month() === lastDay.month()) {
+    //   return firstDay.format(calendarHeaderFormat);
+    // } else if (firstDay.year() !== lastDay.year()) {
+    //   return `${firstDay.format(calendarHeaderFormat)} / ${lastDay.format(
+    //     calendarHeaderFormat
+    //   )}`;
+    // }
+
+    // return `${
+    //   monthFormatting.length > 1 ? firstDay.format(monthFormatting) : ""
+    // } ${monthFormatting.length > 1 ? "/" : ""} ${lastDay.format(
+    //   calendarHeaderFormat
+    // )}`;
   }
 
   render() {

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -545,6 +545,8 @@ class CalendarStrip extends Component {
           customStyle={this.state.datesCustomStylesForWeek[i]}
           size={this.state.dayComponentWidth}
           allowDayTextScaling={this.props.shouldAllowFontScaling}
+          keepDayNameFontSize={this.props.keepDayTextFontSize}
+          keepDayNumberFontSize={this.props.keepDayNumberFontSize} 
         />
       );
       datesRender.push(

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -73,7 +73,9 @@ class CalendarStrip extends Component {
     styleWeekend: PropTypes.bool,
 
     locale: PropTypes.object,
-    shouldAllowFontScaling: PropTypes.bool
+    shouldAllowFontScaling: PropTypes.bool,
+    keepDayNameFontSize: PropTypes.bool,
+    keepDayNumberFontSize: PropTypes.bool
   };
 
   static defaultProps = {
@@ -92,7 +94,9 @@ class CalendarStrip extends Component {
     innerStyle: { flex: 1 },
     maxDayComponentSize: 80,
     minDayComponentSize: 10,
-    shouldAllowFontScaling: true
+    shouldAllowFontScaling: true,
+    keepDayNameFontSize: false,
+    keepDayNumberFontSize: false
   };
 
   constructor(props) {
@@ -545,7 +549,7 @@ class CalendarStrip extends Component {
           customStyle={this.state.datesCustomStylesForWeek[i]}
           size={this.state.dayComponentWidth}
           allowDayTextScaling={this.props.shouldAllowFontScaling}
-          keepDayNameFontSize={this.props.keepDayTextFontSize}
+          keepDayNameFontSize={this.props.keepDayNameFontSize}
           keepDayNumberFontSize={this.props.keepDayNumberFontSize} 
         />
       );


### PR DESCRIPTION
1.  be able to choose to set the header format Sep/Oct 2018 to Sep 2018(firstDay)  or Oct 2018(lastDay). As the header format now for the week span 2 months is too long, will not be able to show properly on small screens. 

2. Able to keep the fontSize for day number and day text, so the user can custom it to the size they want. 