### PR TITLE
Adding standard size to calendar strip (fixing basic example)

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -580,6 +580,7 @@ class CalendarStrip extends Component {
         style={[
           styles.calendarContainer,
           { backgroundColor: this.props.calendarColor },
+          { height: 100, paddingTop: 10, paddingBottom: 10 },
           this.props.style
         ]}
       >


### PR DESCRIPTION
I've been trying to implement this repository for some time and have not been able to get the `Simple "out of the box" Example` working. 
After some investigation this appears to be because the view that contains this component has no inherent size. I added a "default" style to the view that includes size and some padding, this can be easily overwritten using the style prop for this component. 

**tl;dr**
Simple "out of the box" Example not working -> working