### PR TITLE
created typings for `useRef<CalendarStrip>()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,13 @@ declare module "react-native-calendar-strip" {
       shouldAllowFontScaling?: boolean;
     },
     {}
-  > {}
+  > {
+    getSelectedDate: () => undefined | Date | string;
+    setSelectedDate: (date: Date | string) => void;
+    getNextWeek: () => void;
+    getPreviousWeek: () => void;
+    updateWeekView: (date: Date | string, startDate: Date | string) => void;
+  }
 
   export = ReactNativeCalendarStrip;
 }


### PR DESCRIPTION
Created the necessary typings for useRef (https://github.com/BugiDev/react-native-calendar-strip/issues/168)