### PR TITLE
Default prop to remove warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ declare module "react-native-calendar-strip" {
 
       locale?: object;
       shouldAllowFontScaling?: boolean;
+      useNativeDriver?: boolean;
     },
     {}
   > {

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -79,7 +79,8 @@ class CalendarStrip extends Component {
     styleWeekend: PropTypes.bool,
 
     locale: PropTypes.object,
-    shouldAllowFontScaling: PropTypes.bool
+    shouldAllowFontScaling: PropTypes.bool,
+    useNativeDriver: PropTypes.bool
   };
 
   static defaultProps = {
@@ -101,6 +102,7 @@ class CalendarStrip extends Component {
     minDayComponentSize: 10,
     shouldAllowFontScaling: true,
     markedDates: [],
+    useNativeDriver: true
   };
 
   constructor(props) {
@@ -478,7 +480,8 @@ class CalendarStrip extends Component {
           Animated.timing(this.animatedValue[i], {
             toValue: 1,
             duration: this.props.calendarAnimation.duration,
-            easing: Easing.linear
+            easing: Easing.linear,
+            useNativeDriver: this.props.useNativeDriver
           })
         );
       }


### PR DESCRIPTION
Adding a new default prop to remove a Warning coming with a new version of react-native

All the info are in the issue #173 