### PR TITLE
Return cloned moment dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ buck-out/
 android/app/libs
 android/keystores/debug.keystore
 *.sqlite
+*.sqlite-journal

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ buck-out/
 \.buckd/
 android/app/libs
 android/keystores/debug.keystore
+*.sqlite

--- a/README.md
+++ b/README.md
@@ -188,20 +188,22 @@ AppRegistry.registerComponent('Example', () => Example);
 
 ### Initial data and onDateSelected handler
 
-| Prop                 | Description                                                                                                                                                                                  | Type     | Default    |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- |
-| **`scrollable`**     | Dates are scrollable if true.                                                                                                                                                                | Bool     | **`False`**|
-| **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.                             | Any      |
-| **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.                                                                       | Any      |
-| **`onDateSelected`** | Function to be used as a callback when a date is selected. It returns `moment Date`                                                                                                          | Function |
-| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. It returns `moment Date`                                                                                                           | Number   |
-| **`updateWeek`**     | Update the week view if other props change. If `false`, the week view won't change when other props change, but will still respond to left/right selectors.                                  | Bool     | **`True`** |
-| **`useIsoWeekday`**  | start week on ISO day of week (default true). If false, starts week on _startingDate_ parameter.                                                                                             | Bool     | **`True`** |
-| **`minDate`**        | minimum date that the calendar may navigate to. A week is allowed if minDate falls within the current week.                                                                                  | Any      |
-| **`maxDate`**        | maximum date that the calendar may navigate to. A week is allowed if maxDate falls within the current week.                                                                                  | Any      |
+| Prop                 | Description                                                                                                                                                        | Type     | Default    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------- |
+| **`scrollable`**     | Dates are scrollable if true.                                                                                                                                      | Bool     | **`False`**|
+| **`startingDate`**   | Date to be used for centering the calendar/showing the week based on that date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.  | Any      |
+| **`selectedDate`**   | Date to be used as pre selected Date. It is internally wrapped by `moment` so it accepts both `Date` and `moment Date`.                                            | Any      |
+| **`onDateSelected`** | Function to be used as a callback when a date is selected. Receives param `date` Moment date.                                                                      | Function |
+| **`onWeekChanged`**  | Function to be used as a callback when a week is changed. Receives params `(start, end)` Moment dates.                                                     | Function |
+| **`onHeaderSelected`**| Function to be used as a callback when the header is selected. Receives param object `{weekStartDate, weekEndDate}` Moment dates.                                 | Function |
+| **`headerText`**     | Text to use in the header. Use with `onWeekChanged` to receive the visible start & end dates.                                                                      | String  |
+| **`updateWeek`**     | Update the week view if other props change. If `false`, the week view won't change when other props change, but will still respond to left/right selectors.        | Bool     | **`True`** |
+| **`useIsoWeekday`**  | start week on ISO day of week (default true). If false, starts week on _startingDate_ parameter.                                                                   | Bool     | **`True`** |
+| **`minDate`**        | minimum date that the calendar may navigate to. A week is allowed if minDate falls within the current week.                                                        | Any      |
+| **`maxDate`**        | maximum date that the calendar may navigate to. A week is allowed if maxDate falls within the current week.                                                        | Any      |
 | **`datesWhitelist`** | Array of dates that are enabled, or a function callback which receives a date param and returns true if enabled. Array supports ranges specified with an object entry in the array. Check example <a href="#dateswhitelist-array-example">Below</a> | Array or Func |
-| **`datesBlacklist`** | Array of dates that are disabled, or a function callback. Same format as _datesWhitelist_. This overrides dates in _datesWhitelist_.                                                                                          | Array or Func |
-| **`markedDates`**    | Dates that are marked. Format as <a href="#markedDatesFormat-array-example">markedDatesFormat</a>.  | Array   | **[]**
+| **`datesBlacklist`** | Array of dates that are disabled, or a function callback. Same format as _datesWhitelist_. This overrides dates in _datesWhitelist_.                               | Array or Func |
+| **`markedDates`**    | Dates that are marked with dots or lines. Format as <a href="#markeddates-example">markedDatesFormat</a>.                                                          | Array or Func | **[]**
 
 
 ##### datesWhitelist Array Example
@@ -239,25 +241,62 @@ AppRegistry.registerComponent('Example', () => Example);
   );
 ```
 
-##### markedDatesFormat Array Example
+##### markedDates Example
 <div align="center">
-  <img src="https://user-images.githubusercontent.com/6241354/50537547-f1f3af80-0b71-11e9-806d-2ca3294f8b2e.png "react-native-calendar-strip marked dates example" alt="">
+  <img src="https://user-images.githubusercontent.com/6295083/83835989-e1752c00-a6b7-11ea-9104-c79a26438c50.png" alt="marked dates example">
 </div>
 
+`markedDates` may be an array of dates with dots/lines, or a callback that returns the same shaped object for a date passed to it.
+
 ```jsx
-   // Market dates format
-  [
+  // Marked dates array format
+  markedDatesArray = [
     {
-        date: '(string, Date or Moment object)',
-        dots: [
-            {
-              key: (unique number or string),
-              color: string,
-              selectedDotColor: string,
-            },
-        ],
+      date: '(string, Date or Moment object)',
+      dots: [
+        {
+          color: <string>,
+          selectedColor: <string> (optional),
+        },
+      ],
     },
-  ]
+    {
+      date: '(string, Date or Moment object)',
+      lines: [
+        {
+          color: <string>,
+          selectedColor: <string> (optional),
+        },
+      ],
+    },
+  ];
+
+```
+
+```jsx
+  // Marked dates callback
+  markedDatesFunc = date => {
+    // Dot
+    if (date.isoWeekday() === 4) { // Thursdays
+      return {
+        dots:[{
+          color: <string>,
+          selectedColor: <string> (optional),
+        }]
+      };
+    }
+    // Line
+    if (date.isoWeekday() === 6) { // Saturdays
+      return {
+        lines:[{
+          color: <string>,
+          selectedColor: <string> (optional),
+        }]
+      };
+    }
+    return {};
+  }
+
 ```
 
 ### Hiding Components
@@ -551,6 +590,12 @@ const locale = {
 
 </details>
 </br>
+
+## Device Specific Notes
+
+<ul>
+<li>OnePlus devices use OnePlus Slate font by default which causes text being cut off in the date number in react-native-calendar-strip. To overcome this change the default font of the device or use a specific font throughout your app.</li>
+</ul>
 
 ## Development with Sample Application
 

--- a/example/App.js
+++ b/example/App.js
@@ -29,21 +29,25 @@ export default class App extends Component<{}> {
         dateContainerStyle: { backgroundColor: `#${(`#00000${(Math.random() * (1 << 24) | 0).toString(16)}`).slice(-6)}` },
       });
 
-      let dots = [{
-        key: i,
-        color: 'red',
-        selectedDotColor: 'yellow',
-      }];
-      if (i % 2) {  // add second dot to alternating days
+      let dots = [];
+      let lines = [];
+
+      if (i % 2) {
+        lines.push({
+          color: 'cyan',
+          selectedColor: 'orange',
+        });
+      }
+      else {
         dots.push({
-          key: i + 'b',
-          color: 'blue',
-          selectedDotColor: 'yellow',
+          color: 'red',
+          selectedColor: 'yellow',
         });
       }
       markedDates.push({
         date,
         dots,
+        lines
       });
     }
 

--- a/example/App.js
+++ b/example/App.js
@@ -10,84 +10,92 @@ import CalendarStrip from './CalendarStrip/CalendarStrip';
 import moment from 'moment';
 
 export default class App extends Component<{}> {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    let startDate = moment(); // today
+        let startDate = moment(); // today
 
-    // Create a week's worth of custom date styles and marked dates.
-    let customDatesStyles = [];
-    let markedDates = [];
-    for (let i=0; i<7; i++) {
-      let date = startDate.clone().add(i, 'days');
+        // Create a week's worth of custom date styles and marked dates.
+        let customDatesStyles = [];
+        let markedDates = [];
+        for (let i = 0; i < 7; i++) {
+            let date = startDate.clone().add(i, 'days');
 
-      customDatesStyles.push({
-        startDate: date, // Single date since no endDate provided
-        dateNameStyle: {color: 'blue'},
-        dateNumberStyle: {color: 'purple'},
-        // Random color...
-        dateContainerStyle: { backgroundColor: `#${(`#00000${(Math.random() * (1 << 24) | 0).toString(16)}`).slice(-6)}` },
-      });
+            customDatesStyles.push({
+                startDate: date, // Single date since no endDate provided
+                dateNameStyle: { color: 'blue' },
+                dateNumberStyle: { color: 'purple' },
+                // Random color...
+                dateContainerStyle: { backgroundColor: `#${(`#00000${(Math.random() * (1 << 24) | 0).toString(16)}`).slice(-6)}` },
+            });
 
-      let dots = [];
-      let lines = [];
+            let dots = [];
+            let lines = [];
 
-      if (i % 2) {
-        lines.push({
-          color: 'cyan',
-          selectedColor: 'orange',
-        });
-      }
-      else {
-        dots.push({
-          color: 'red',
-          selectedColor: 'yellow',
-        });
-      }
-      markedDates.push({
-        date,
-        dots,
-        lines
-      });
+            if (i % 2) {
+                lines.push({
+                    color: 'cyan',
+                    selectedColor: 'orange',
+                });
+            }
+            else {
+                dots.push({
+                    color: 'red',
+                    selectedColor: 'yellow',
+                });
+            }
+            markedDates.push({
+                date,
+                dots,
+                lines
+            });
+        }
+
+        this.state = {
+            selectedDate: '',
+            customDatesStyles,
+            markedDates,
+            startDate,
+            weekStartDate: ""
+        };
     }
 
-    this.state = {
-      selectedDate: '',
-      customDatesStyles,
-      markedDates,
-      startDate,
-    };
-  }
+    datesBlacklistFunc = date => {
+        return date.isoWeekday() === 6; // disable Saturdays
+    }
 
-  datesBlacklistFunc = date => {
-    return date.isoWeekday() === 6; // disable Saturdays
-  }
+    onDateSelected = date => {
+        this.setState({ formattedDate: date.format('YYYY-MM-DD') });
+    }
 
-  onDateSelected = date => {
-    this.setState({ formattedDate: date.format('YYYY-MM-DD')});
-  }
+    //check that calling endOf on start date does not move the week by only 1 day
+    handleWeekChanged = (start, end) => {
+        this.setState({ weekStartDate: start.endOf('week').format("YYYY-MM-DD") });
+    }
 
-  render() {
-    return (
-      <View>
-        <CalendarStrip
-          scrollable
-          calendarAnimation={{type: 'sequence', duration: 30}}
-          daySelectionAnimation={{type: 'background', duration: 300, highlightColor: '#9265DC'}}
-          style={{height:200, paddingTop: 20, paddingBottom: 10}}
-          calendarHeaderStyle={{color: 'white'}}
-          calendarColor={'#3343CE'}
-          dateNumberStyle={{color: 'white'}}
-          dateNameStyle={{color: 'white'}}
-          iconContainer={{flex: 0.1}}
-          customDatesStyles={this.state.customDatesStyles}
-          markedDates={this.state.markedDates}
-          datesBlacklist={this.datesBlacklistFunc}
-          onDateSelected={this.onDateSelected}
-          useIsoWeekday={false}
-        />
-        <Text style={{fontSize: 24}}>Selected Date: {this.state.formattedDate}</Text>
-      </View>
-    );
-  }
+    render() {
+        return (
+            <View>
+                <CalendarStrip
+                    scrollable
+                    calendarAnimation={{ type: 'sequence', duration: 30 }}
+                    daySelectionAnimation={{ type: 'background', duration: 300, highlightColor: '#9265DC' }}
+                    style={{ height: 200, paddingTop: 20, paddingBottom: 10 }}
+                    calendarHeaderStyle={{ color: 'white' }}
+                    calendarColor={'#3343CE'}
+                    dateNumberStyle={{ color: 'white' }}
+                    dateNameStyle={{ color: 'white' }}
+                    iconContainer={{ flex: 0.1 }}
+                    customDatesStyles={this.state.customDatesStyles}
+                    markedDates={this.state.markedDates}
+                    datesBlacklist={this.datesBlacklistFunc}
+                    onDateSelected={this.onDateSelected}
+                    useIsoWeekday={false}
+                    onWeekChanged={this.handleWeekChanged}
+                />
+                <Text style={{ fontSize: 24 }}>Selected Date: {this.state.formattedDate}</Text>
+                <Text style={{ fontSize: 24 }}>Start of Week: {this.state.weekStartDate}</Text>
+            </View>
+        );
+    }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "~37.0.3",
+    "expo": "^37.0.12",
     "moment": "*",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
@@ -18,9 +18,9 @@
     "recyclerlistview": "^3.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.8.6",
     "@deboxsoft/cpx": "^1.5.0",
-    "babel-preset-expo": "~8.1.0",
-    "@babel/core": "^7.8.6"
+    "babel-preset-expo": "~8.1.0"
   },
   "private": true
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,14 +46,14 @@ declare module "react-native-calendar-strip" {
     highlightDateNumberStyle: TextStyle;
     disabledDateNameStyle: TextStyle;
     disabledDateNumberStyle: TextStyle;
-    markedDatesStyle: TextStyle;
     disabledDateOpacity: number;
     styleWeekend: boolean;
     daySelectionAnimation: TDaySelectionAnimation;
     customStyle: ViewStyle;
     size: number;
     allowDayTextScaling: boolean;
-    markedDates: [];
+    markedDatesStyle: TextStyle;
+    markedDates?: any[];
   }
 
   type TDaySelectionAnimation =
@@ -74,7 +74,8 @@ declare module "react-native-calendar-strip" {
       startingDate?: Date;
       selectedDate?: Date;
       onDateSelected?: (date: Date) => void;
-      onWeekChanged?: (date: Date) => void;
+      onWeekChanged?: (start: Date, end: Date) => void;
+      onHeaderSelected?: ({weekStartDate: Date, weekEndDate: Date}) => void;
       updateWeek?: boolean;
       useIsoWeekday?: boolean;
       minDate?: Date;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/BugiDev/react-native-calendar-strip/issues"
   },
-  "version": "2.0.1",
+  "version": "2.0.3",
   "main": "index.js",
   "directories": {
     "example": "example"

--- a/src/Calendar.style.js
+++ b/src/Calendar.style.js
@@ -80,4 +80,22 @@ export default StyleSheet.create({
   selectedDot: {
     backgroundColor: 'blue'
   },
+
+  // Calendar Lines
+  line: {
+    height: 4,
+    marginTop: 3,
+    borderRadius: 1,
+    opacity: 0
+  },
+  linesContainer: {
+    justifyContent: 'center'
+  },
+  visibleLine: {
+    opacity: 1,
+    backgroundColor: 'blue'
+  },
+  selectedLine: {
+    backgroundColor: 'blue'
+  },
 });

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -18,7 +18,7 @@ class CalendarDay extends Component {
     datesWhitelist: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     datesBlacklist: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
 
-    markedDates: PropTypes.array,
+    markedDates: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
 
     showDayName: PropTypes.bool,
     showDayNumber: PropTypes.bool,
@@ -88,7 +88,7 @@ class CalendarDay extends Component {
     let hasDateChanged = prevProps.date !== this.props.date;
 
     if ((this.props.selectedDate !== prevProps.selectedDate) || hasDateChanged) {
-      if (this.props.daySelectionAnimation.type !== "") {
+      if (this.props.daySelectionAnimation.type !== "" && !this.props.scrollable) {
         let configurableAnimation = {
           duration: this.props.daySelectionAnimation.duration || 300,
           create: {
@@ -236,14 +236,13 @@ class CalendarDay extends Component {
   }
 
   getDateMarking = (day, markedDates) => {
-    if (markedDates.length === 0) {
-      return {};
-    }
-    const date = markedDates.find(item => moment(day).isSame(item.date, "day"))
-    if (date && date.dots.length > 0) {
-      return date;
-    } else {
-      return {}
+    if (Array.isArray(markedDates)) {
+      if (markedDates.length === 0) {
+        return {};
+      }
+      return markedDates.find(md => moment(day).isSame(md.date, "day")) || {};
+    } else if (markedDates instanceof Function) {
+      return markedDates(day) || {};
     }
   }
 
@@ -268,36 +267,83 @@ class CalendarDay extends Component {
     }
   }
 
-  renderDots() {
+  renderMarking() {
     if (!this.props.markedDates || this.props.markedDates.length === 0) {
       return;
     }
     const marking = this.state.marking;
-    const baseDotStyle = [styles.dot, styles.visibleDot];
-    const markedDatesStyle = this.props.markedDatesStyle || {};
-    let validDots = <View style={[styles.dot]} />; // default empty view for no dots case
 
     if (marking.dots && Array.isArray(marking.dots) && marking.dots.length > 0) {
-      // Filter out dots so that we we process only those items which have key and color property
-      validDots = marking.dots
-        .filter(d => (d && d.color))
-        .map((dot, index) => {
-        return (
-          <View
-            key={dot.key ? dot.key : index}
-            style={[
-              baseDotStyle,
-              { backgroundColor: marking.selected && dot.selectedDotColor ? dot.selectedDotColor : dot.color },
-              markedDatesStyle
-            ]}
-          />
-        );
-      });
+      return this.renderDots(marking);
     }
+    if (marking.lines && Array.isArray(marking.lines) && marking.lines.length > 0) {
+      return this.renderLines(marking);
+    }
+
+    return ( // default empty spacer
+      <View style={styles.dotsContainer}>
+        <View style={[styles.dot]} />
+      </View>
+    );
+  }
+
+  renderDots(marking) {
+    const baseDotStyle = [styles.dot, styles.visibleDot];
+    const markedDatesStyle = this.props.markedDatesStyle || {};
+    const formattedDate = this.props.date.format('YYYY-MM-DD');
+    let validDots = <View style={[styles.dot]} />; // default empty view for no dots case
+
+    // Filter dots and process only those which have color property
+    validDots = marking.dots
+      .filter(d => (d && d.color))
+      .map((dot, index) => {
+      const selectedColor = dot.selectedColor || dot.selectedDotColor; // selectedDotColor deprecated
+      const backgroundColor = this.state.selected && selectedColor ? selectedColor : dot.color;
+      return (
+        <View
+          key={dot.key || (formattedDate + index)}
+          style={[
+            baseDotStyle,
+            { backgroundColor },
+            markedDatesStyle
+          ]}
+        />
+      );
+    });
 
     return (
       <View style={styles.dotsContainer}>
         {validDots}
+      </View>
+    );
+  }
+
+  renderLines(marking) {
+    const baseLineStyle = [styles.line, styles.visibleLine];
+    const markedDatesStyle = this.props.markedDatesStyle || {};
+    let validLines = <View style={[styles.line]} />; // default empty view
+
+    // Filter lines and process only those which have color property
+    validLines = marking.lines
+      .filter(d => (d && d.color))
+      .map((line, index) => {
+      const backgroundColor = this.state.selected && line.selectedColor ? line.selectedColor : line.color;
+      const width = this.props.size * 0.6;
+      return (
+        <View
+          key={line.key ? line.key : index}
+          style={[
+            baseLineStyle,
+            { backgroundColor, width },
+            markedDatesStyle
+          ]}
+        />
+      );
+    });
+
+    return (
+      <View style={styles.linesContainer}>
+        {validLines}
       </View>
     );
   }
@@ -431,7 +477,7 @@ class CalendarDay extends Component {
                 >
                   {date.date()}
                 </Text>
-                { this.renderDots() }
+                { this.renderMarking() }
               </View>
             )}
           </View>

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -6,7 +6,14 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 
-import { Text, View, Animated, Easing, LayoutAnimation, TouchableOpacity } from "react-native";
+import {
+  Text,
+  View,
+  Animated,
+  Easing,
+  LayoutAnimation,
+  TouchableOpacity
+} from "react-native";
 import styles from "./Calendar.style.js";
 
 class CalendarDay extends Component {
@@ -44,7 +51,7 @@ class CalendarDay extends Component {
     registerAnimation: PropTypes.func.isRequired,
     daySelectionAnimation: PropTypes.object,
     useNativeDriver: PropTypes.bool,
-    scrollable: PropTypes.bool,
+    scrollable: PropTypes.bool
   };
 
   // Reference: https://medium.com/@Jpoliachik/react-native-s-layoutanimation-is-awesome-4a4d317afd3e
@@ -69,7 +76,11 @@ class CalendarDay extends Component {
     super(props);
 
     this.state = {
-      enabled: this.isDateAllowed(props.date, props.datesBlacklist, props.datesWhitelist),
+      enabled: this.isDateAllowed(
+        props.date,
+        props.datesBlacklist,
+        props.datesWhitelist
+      ),
       selected: this.isDateSelected(props.date, props.selectedDate),
       customStyle: this.getCustomDateStyle(props.date, props.customDatesStyles),
       marking: this.getDateMarking(props.date, props.markedDates),
@@ -87,8 +98,11 @@ class CalendarDay extends Component {
     let doStateUpdate = false;
     let hasDateChanged = prevProps.date !== this.props.date;
 
-    if ((this.props.selectedDate !== prevProps.selectedDate) || hasDateChanged) {
-      if (this.props.daySelectionAnimation.type !== "" && !this.props.scrollable) {
+    if (this.props.selectedDate !== prevProps.selectedDate || hasDateChanged) {
+      if (
+        this.props.daySelectionAnimation.type !== "" &&
+        !this.props.scrollable
+      ) {
         let configurableAnimation = {
           duration: this.props.daySelectionAnimation.duration || 300,
           create: {
@@ -116,7 +130,10 @@ class CalendarDay extends Component {
         };
         LayoutAnimation.configureNext(configurableAnimation);
       }
-      newState.selected = this.isDateSelected(this.props.date, this.props.selectedDate);
+      newState.selected = this.isDateSelected(
+        this.props.date,
+        this.props.selectedDate
+      );
       doStateUpdate = true;
     }
 
@@ -125,21 +142,41 @@ class CalendarDay extends Component {
       doStateUpdate = true;
     }
 
-    if ((prevProps.customDatesStyles !== this.props.customDatesStyles) || hasDateChanged) {
-      newState = { ...newState, customStyle: this.getCustomDateStyle(this.props.date, this.props.customDatesStyles) };
+    if (
+      prevProps.customDatesStyles !== this.props.customDatesStyles ||
+      hasDateChanged
+    ) {
+      newState = {
+        ...newState,
+        customStyle: this.getCustomDateStyle(
+          this.props.date,
+          this.props.customDatesStyles
+        )
+      };
       doStateUpdate = true;
     }
 
-    if ((prevProps.markedDates !== this.props.markedDates) || hasDateChanged) {
-      newState = { ...newState, marking: this.getDateMarking(this.props.date, this.props.markedDates) };
+    if (prevProps.markedDates !== this.props.markedDates || hasDateChanged) {
+      newState = {
+        ...newState,
+        marking: this.getDateMarking(this.props.date, this.props.markedDates)
+      };
       doStateUpdate = true;
     }
 
-    if ((prevProps.datesBlacklist !== this.props.datesBlacklist) ||
-        (prevProps.datesWhitelist !== this.props.datesWhitelist) ||
-        hasDateChanged)
-    {
-      newState = { ...newState, enabled: this.isDateAllowed(this.props.date, this.props.datesBlacklist, this.props.datesWhitelist) };
+    if (
+      prevProps.datesBlacklist !== this.props.datesBlacklist ||
+      prevProps.datesWhitelist !== this.props.datesWhitelist ||
+      hasDateChanged
+    ) {
+      newState = {
+        ...newState,
+        enabled: this.isDateAllowed(
+          this.props.date,
+          this.props.datesBlacklist,
+          this.props.datesWhitelist
+        )
+      };
       doStateUpdate = true;
     }
 
@@ -155,7 +192,7 @@ class CalendarDay extends Component {
       dateNameFontSize: Math.round(props.size / 5),
       dateNumberFontSize: Math.round(props.size / 2.9)
     };
-  }
+  };
 
   //Function to check if provided date is the same as selected one, hence date is selected
   //using isSame moment query with "day" param so that it check years, months and day
@@ -164,7 +201,7 @@ class CalendarDay extends Component {
       return date === selectedDate;
     }
     return date.isSame(selectedDate, "day");
-  }
+  };
 
   // Check whether date is allowed
   isDateAllowed = (date, datesBlacklist, datesWhitelist) => {
@@ -206,7 +243,7 @@ class CalendarDay extends Component {
     }
 
     return true;
-  }
+  };
 
   getCustomDateStyle = (date, customDatesStyles) => {
     if (Array.isArray(customDatesStyles)) {
@@ -233,7 +270,7 @@ class CalendarDay extends Component {
     } else if (customDatesStyles instanceof Function) {
       return customDatesStyles(date);
     }
-  }
+  };
 
   getDateMarking = (day, markedDates) => {
     if (Array.isArray(markedDates)) {
@@ -244,20 +281,17 @@ class CalendarDay extends Component {
     } else if (markedDates instanceof Function) {
       return markedDates(day) || {};
     }
-  }
+  };
 
   createAnimation = () => {
-    const {
-      calendarAnimation,
-      useNativeDriver,
-    } = this.props
+    const { calendarAnimation, useNativeDriver } = this.props;
 
     if (calendarAnimation) {
       this.animation = Animated.timing(this.state.animatedValue, {
         toValue: 1,
         duration: calendarAnimation.duration,
         easing: Easing.linear,
-        useNativeDriver,
+        useNativeDriver
       });
 
       // Individual CalendarDay animation starts have unpredictable timing
@@ -265,7 +299,7 @@ class CalendarDay extends Component {
       // Send animation to parent to collect and start together.
       return this.animation;
     }
-  }
+  };
 
   renderMarking() {
     if (!this.props.markedDates || this.props.markedDates.length === 0) {
@@ -273,14 +307,23 @@ class CalendarDay extends Component {
     }
     const marking = this.state.marking;
 
-    if (marking.dots && Array.isArray(marking.dots) && marking.dots.length > 0) {
+    if (
+      marking.dots &&
+      Array.isArray(marking.dots) &&
+      marking.dots.length > 0
+    ) {
       return this.renderDots(marking);
     }
-    if (marking.lines && Array.isArray(marking.lines) && marking.lines.length > 0) {
+    if (
+      marking.lines &&
+      Array.isArray(marking.lines) &&
+      marking.lines.length > 0
+    ) {
       return this.renderLines(marking);
     }
 
-    return ( // default empty spacer
+    return (
+      // default empty spacer
       <View style={styles.dotsContainer}>
         <View style={[styles.dot]} />
       </View>
@@ -290,32 +333,23 @@ class CalendarDay extends Component {
   renderDots(marking) {
     const baseDotStyle = [styles.dot, styles.visibleDot];
     const markedDatesStyle = this.props.markedDatesStyle || {};
-    const formattedDate = this.props.date.format('YYYY-MM-DD');
+    const formattedDate = this.props.date.format("YYYY-MM-DD");
     let validDots = <View style={[styles.dot]} />; // default empty view for no dots case
 
     // Filter dots and process only those which have color property
-    validDots = marking.dots
-      .filter(d => (d && d.color))
-      .map((dot, index) => {
+    validDots = marking.dots.filter(d => d && d.color).map((dot, index) => {
       const selectedColor = dot.selectedColor || dot.selectedDotColor; // selectedDotColor deprecated
-      const backgroundColor = this.state.selected && selectedColor ? selectedColor : dot.color;
+      const backgroundColor =
+        this.state.selected && selectedColor ? selectedColor : dot.color;
       return (
         <View
-          key={dot.key || (formattedDate + index)}
-          style={[
-            baseDotStyle,
-            { backgroundColor },
-            markedDatesStyle
-          ]}
+          key={dot.key || formattedDate + index}
+          style={[baseDotStyle, { backgroundColor }, markedDatesStyle]}
         />
       );
     });
 
-    return (
-      <View style={styles.dotsContainer}>
-        {validDots}
-      </View>
-    );
+    return <View style={styles.dotsContainer}>{validDots}</View>;
   }
 
   renderLines(marking) {
@@ -324,28 +358,21 @@ class CalendarDay extends Component {
     let validLines = <View style={[styles.line]} />; // default empty view
 
     // Filter lines and process only those which have color property
-    validLines = marking.lines
-      .filter(d => (d && d.color))
-      .map((line, index) => {
-      const backgroundColor = this.state.selected && line.selectedColor ? line.selectedColor : line.color;
+    validLines = marking.lines.filter(d => d && d.color).map((line, index) => {
+      const backgroundColor =
+        this.state.selected && line.selectedColor
+          ? line.selectedColor
+          : line.color;
       const width = this.props.size * 0.6;
       return (
         <View
           key={line.key ? line.key : index}
-          style={[
-            baseLineStyle,
-            { backgroundColor, width },
-            markedDatesStyle
-          ]}
+          style={[baseLineStyle, { backgroundColor, width }, markedDatesStyle]}
         />
       );
     });
 
-    return (
-      <View style={styles.linesContainer}>
-        {validLines}
-      </View>
-    );
+    return <View style={styles.linesContainer}>{validLines}</View>;
   }
 
   render() {
@@ -369,7 +396,7 @@ class CalendarDay extends Component {
       showDayNumber,
       allowDayTextScaling,
       dayComponent: DayComponent,
-      scrollable,
+      scrollable
     } = this.props;
     const {
       enabled,
@@ -378,11 +405,17 @@ class CalendarDay extends Component {
       containerBorderRadius,
       customStyle,
       dateNameFontSize,
-      dateNumberFontSize,
+      dateNumberFontSize
     } = this.state;
 
-    let _dateNameStyle = [styles.dateName, enabled ? dateNameStyle : disabledDateNameStyle];
-    let _dateNumberStyle = [styles.dateNumber, enabled ? dateNumberStyle : disabledDateNumberStyle];
+    let _dateNameStyle = [
+      styles.dateName,
+      enabled ? dateNameStyle : disabledDateNameStyle
+    ];
+    let _dateNumberStyle = [
+      styles.dateNumber,
+      enabled ? dateNumberStyle : disabledDateNumberStyle
+    ];
     let _dateViewStyle = enabled
       ? [{ backgroundColor: "transparent" }]
       : [{ opacity: disabledDateOpacity }];
@@ -399,7 +432,9 @@ class CalendarDay extends Component {
       //If it is border, the user has to input color for border animation
       switch (daySelectionAnimation.type) {
         case "background":
-          _dateViewStyle.push({ backgroundColor: daySelectionAnimation.highlightColor });
+          _dateViewStyle.push({
+            backgroundColor: daySelectionAnimation.highlightColor
+          });
           break;
         case "border":
           _dateViewStyle.push({
@@ -414,38 +449,29 @@ class CalendarDay extends Component {
 
       _dateNameStyle = [styles.dateName, dateNameStyle];
       _dateNumberStyle = [styles.dateNumber, dateNumberStyle];
-      if (styleWeekend &&
+      if (
+        styleWeekend &&
         (date.isoWeekday() === 6 || date.isoWeekday() === 7)
       ) {
-        _dateNameStyle = [
-          styles.weekendDateName,
-          weekendDateNameStyle
-        ];
-        _dateNumberStyle = [
-          styles.weekendDateNumber,
-          weekendDateNumberStyle
-        ];
+        _dateNameStyle = [styles.weekendDateName, weekendDateNameStyle];
+        _dateNumberStyle = [styles.weekendDateNumber, weekendDateNumberStyle];
       }
       if (selected) {
         _dateNameStyle = [styles.dateName, highlightDateNameStyle];
-        _dateNumberStyle = [
-          styles.dateNumber,
-          highlightDateNumberStyle
-        ];
+        _dateNumberStyle = [styles.dateNumber, highlightDateNumberStyle];
       }
     }
 
     let responsiveDateContainerStyle = {
       width: containerSize,
       height: containerSize,
-      borderRadius: containerBorderRadius,
+      borderRadius: containerBorderRadius
     };
 
     let day;
     if (DayComponent) {
-      day = (<DayComponent {...this.props} {...this.state}/>);
-    }
-    else {
+      day = <DayComponent {...this.props} {...this.state} />;
+    } else {
       day = (
         <TouchableOpacity
           onPress={onDateSelected.bind(this, date)}
@@ -469,15 +495,12 @@ class CalendarDay extends Component {
             {showDayNumber && (
               <View>
                 <Text
-                  style={[
-                      { fontSize: dateNumberFontSize },
-                      _dateNumberStyle
-                  ]}
+                  style={[{ fontSize: dateNumberFontSize }, _dateNumberStyle]}
                   allowFontScaling={allowDayTextScaling}
                 >
                   {date.date()}
                 </Text>
-                { this.renderMarking() }
+                {this.renderMarking()}
               </View>
             )}
           </View>
@@ -486,16 +509,16 @@ class CalendarDay extends Component {
     }
 
     return calendarAnimation && !scrollable ? (
-      <Animated.View style={[
-        styles.dateRootContainer,
-        {opacity: this.state.animatedValue}
-      ]}>
+      <Animated.View
+        style={[
+          styles.dateRootContainer,
+          { opacity: this.state.animatedValue }
+        ]}
+      >
         {day}
       </Animated.View>
     ) : (
-      <View style={styles.dateRootContainer}>
-        {day}
-      </View>
+      <View style={styles.dateRootContainer}>{day}</View>
     );
   }
 }

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Text, View } from "react-native";
+import { Text, TouchableOpacity } from "react-native";
 
 import styles from "./Calendar.style.js";
 
@@ -19,6 +19,8 @@ class CalendarHeader extends Component {
     weekEndDate: PropTypes.object,
     allowHeaderTextScaling: PropTypes.bool,
     fontSize: PropTypes.number,
+    headerText: PropTypes.string,
+    onHeaderSelected: PropTypes.func,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -66,20 +68,36 @@ class CalendarHeader extends Component {
   }
 
   render() {
-    const headerText = this.formatCalendarHeader(this.props.calendarHeaderFormat);
+    const {
+      calendarHeaderFormat,
+      onHeaderSelected,
+      calendarHeaderContainerStyle,
+      calendarHeaderStyle,
+      fontSize,
+      allowHeaderTextScaling,
+      weekStartDate,
+      weekEndDate,
+      headerText,
+    } = this.props;
+    const _headerText = headerText || this.formatCalendarHeader(calendarHeaderFormat);
+
     return (
-      <View style={this.props.calendarHeaderContainerStyle}>
+      <TouchableOpacity
+        onPress={onHeaderSelected && onHeaderSelected.bind(this, {weekStartDate, weekEndDate})}
+        disabled={!onHeaderSelected}
+        style={calendarHeaderContainerStyle}
+      >
         <Text
           style={[
             styles.calendarHeader,
-            { fontSize: this.props.fontSize },
-            this.props.calendarHeaderStyle
+            { fontSize: fontSize },
+            calendarHeaderStyle
           ]}
-          allowFontScaling={this.props.allowHeaderTextScaling}
+          allowFontScaling={allowHeaderTextScaling}
         >
-          {headerText}
+          {_headerText}
         </Text>
-      </View>
+      </TouchableOpacity>
     );
   }
 }

--- a/src/CalendarHeader.js
+++ b/src/CalendarHeader.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Text, TouchableOpacity } from "react-native";
+import moment from "moment";
 
 import styles from "./Calendar.style.js";
 
@@ -20,7 +21,7 @@ class CalendarHeader extends Component {
     allowHeaderTextScaling: PropTypes.bool,
     fontSize: PropTypes.number,
     headerText: PropTypes.string,
-    onHeaderSelected: PropTypes.func,
+    onHeaderSelected: PropTypes.func
   };
 
   shouldComponentUpdate(nextProps) {
@@ -77,13 +78,20 @@ class CalendarHeader extends Component {
       allowHeaderTextScaling,
       weekStartDate,
       weekEndDate,
-      headerText,
+      headerText
     } = this.props;
-    const _headerText = headerText || this.formatCalendarHeader(calendarHeaderFormat);
-
+    const _headerText =
+      headerText || this.formatCalendarHeader(calendarHeaderFormat);
+    //return cloned moment dates rather than internal moment objects
     return (
       <TouchableOpacity
-        onPress={onHeaderSelected && onHeaderSelected.bind(this, {weekStartDate, weekEndDate})}
+        onPress={
+          onHeaderSelected &&
+          onHeaderSelected.bind(this, {
+            weekStartDate: moment(weekStartDate),
+            weekEndDate: moment(weekEndDate)
+          })
+        }
         disabled={!onHeaderSelected}
         style={calendarHeaderContainerStyle}
       >

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -148,12 +148,12 @@ class CalendarStrip extends Component {
 
     if (!this.compareDates(prevProps.startingDate, this.props.startingDate)) {
       updateState = true;
-      startingDate = { startingDate: this.setLocale(this.props.startingDate)};
+      startingDate = { startingDate: this.setLocale(this.props.startingDate) };
       days = this.createDays(startingDate.startingDate);
     }
 
     if (updateState) {
-      this.setState({...startingDate, ...days });
+      this.setState({ ...startingDate, ...days });
     }
   }
 
@@ -179,13 +179,12 @@ class CalendarStrip extends Component {
   // JS date, or ISO 8601 strings.
   // Returns true if the datetimes values are the same; false otherwise.
   compareDates = (date1, date2) => {
-    if (date1 && date1.valueOf && date2 && date2.valueOf)
-    {
+    if (date1 && date1.valueOf && date2 && date2.valueOf) {
       return moment(date1).isSame(date2, "day");
     } else {
       return JSON.stringify(date1) === JSON.stringify(date2);
     }
-  }
+  };
 
   //Function that checks if the locale is passed to the component and sets it to the passed date
   setLocale = date => {
@@ -194,7 +193,7 @@ class CalendarStrip extends Component {
       _date = _date.locale(this.props.locale.name);
     }
     return _date;
-  }
+  };
 
   getInitialStartingDate = () => {
     if (this.props.startingDate) {
@@ -205,7 +204,7 @@ class CalendarStrip extends Component {
       let date = this.setLocale(moment(this.props.selectedDate));
       return this.props.useIsoWeekday ? date.startOf("isoweek") : date;
     }
-  }
+  };
 
   //Set startingDate to the previous week
   getPreviousWeek = () => {
@@ -214,10 +213,12 @@ class CalendarStrip extends Component {
       return;
     }
     this.animations = [];
-    const previousWeekStartDate = this.state.startingDate.clone().subtract(1, "w");
+    const previousWeekStartDate = this.state.startingDate
+      .clone()
+      .subtract(1, "w");
     const days = this.createDays(previousWeekStartDate);
     this.setState({ startingDate: previousWeekStartDate, ...days });
-  }
+  };
 
   //Set startingDate to the next week
   getNextWeek = () => {
@@ -229,11 +230,14 @@ class CalendarStrip extends Component {
     const nextWeekStartDate = this.state.startingDate.clone().add(1, "w");
     const days = this.createDays(nextWeekStartDate);
     this.setState({ startingDate: nextWeekStartDate, ...days });
-  }
+  };
 
   // Set the current visible week to the selectedDate
   // When date param is undefined, an update always occurs (e.g. initialize)
-  updateWeekStart = (newStartDate, originalStartDate = this.state.startingDate) => {
+  updateWeekStart = (
+    newStartDate,
+    originalStartDate = this.state.startingDate
+  ) => {
     if (!this.props.updateWeek) {
       return originalStartDate;
     }
@@ -251,7 +255,7 @@ class CalendarStrip extends Component {
     startingDate = originalStartDate[addOrSubtract](adjustWeeks, "w");
 
     return this.setLocale(startingDate);
-  }
+  };
 
   // updateWeekView allows external callers to update the visible week.
   updateWeekView = date => {
@@ -262,26 +266,29 @@ class CalendarStrip extends Component {
 
     this.animations = [];
     let startingDate = moment(date);
-    startingDate = this.props.useIsoWeekday ? startingDate.startOf("isoweek") : startingDate;
+    startingDate = this.props.useIsoWeekday
+      ? startingDate.startOf("isoweek")
+      : startingDate;
     const days = this.createDays(startingDate);
-    this.setState({startingDate, ...days});
-  }
+    this.setState({ startingDate, ...days });
+  };
 
   //Handling press on date/selecting date
   onDateSelected = selectedDate => {
     let newState;
     if (this.props.scrollable) {
       newState = { selectedDate };
-    }
-    else {
+    } else {
       newState = {
         selectedDate,
-        ...this.createDays(this.state.startingDate, selectedDate),
+        ...this.createDays(this.state.startingDate, selectedDate)
       };
     }
     this.setState(newState);
-    this.props.onDateSelected && this.props.onDateSelected(selectedDate);
-  }
+    //return a new moment object rather than the object being used internally
+    this.props.onDateSelected &&
+      this.props.onDateSelected(moment(selectedDate));
+  };
 
   // Get the currently selected date (Moment JS object)
   getSelectedDate = date => {
@@ -289,13 +296,13 @@ class CalendarStrip extends Component {
       return; // undefined (no date has been selected yet)
     }
     return this.state.selectedDate;
-  }
+  };
 
   // Set the selected date.  To clear the currently selected date, pass in 0.
   setSelectedDate = date => {
     let mDate = moment(date);
     this.onDateSelected(mDate);
-  }
+  };
 
   // Gather animations from each day. Sequence animations must be started
   // together to work around bug in RN Animated with individual starts.
@@ -304,12 +311,11 @@ class CalendarStrip extends Component {
     if (this.animations.length >= this.state.days.length) {
       if (this.props.calendarAnimation?.type.toLowerCase() === "sequence") {
         Animated.sequence(this.animations).start();
-      }
-      else {
+      } else {
         Animated.parallel(this.animations).start();
       }
     }
-  }
+  };
 
   // Responsive sizing based on container width.
   // Debounce to prevent rapid succession of onLayout calls from thrashing.
@@ -325,7 +331,7 @@ class CalendarStrip extends Component {
       this.onLayoutDebounce(this.layout);
       this.onLayoutTimer = null;
     }, 100);
-  }
+  };
 
   onLayoutDebounce = layout => {
     const {
@@ -334,7 +340,7 @@ class CalendarStrip extends Component {
       minDayComponentSize,
       showMonth,
       showDate,
-      scrollable,
+      scrollable
     } = this.props;
     let csWidth = PixelRatio.roundToNearestPixel(layout.width);
     let numElements = this.numDaysInWeek;
@@ -355,28 +361,30 @@ class CalendarStrip extends Component {
     height += showDate ? dayComponentWidth : 0; // assume square element sizes
     selectorSize = Math.min(selectorSize, height);
 
-    this.setState({
-      dayComponentWidth,
-      height,
-      monthFontSize,
-      selectorSize,
-      marginHorizontal,
-      numVisibleDays,
-    },
-    () => this.setState( {...this.createDays(this.state.startingDate)} ));
-  }
+    this.setState(
+      {
+        dayComponentWidth,
+        height,
+        monthFontSize,
+        selectorSize,
+        marginHorizontal,
+        numVisibleDays
+      },
+      () => this.setState({ ...this.createDays(this.state.startingDate) })
+    );
+  };
 
   getItemLayout = (data, index) => {
     const length = this.state.height * 1.05; //include margin
-    return { length, offset: length * index, index }
-  }
+    return { length, offset: length * index, index };
+  };
 
   updateMonthYear = (weekStartDate, weekEndDate) => {
     this.setState({
       weekStartDate,
-      weekEndDate,
+      weekEndDate
     });
-  }
+  };
 
   createDayProps = selectedDate => {
     return {
@@ -408,9 +416,9 @@ class CalendarStrip extends Component {
       markedDates: this.props.markedDates,
       size: this.state.dayComponentWidth,
       marginHorizontal: this.state.marginHorizontal,
-      allowDayTextScaling: this.props.shouldAllowFontScaling,
-    }
-  }
+      allowDayTextScaling: this.props.shouldAllowFontScaling
+    };
+  };
 
   createDays = (startingDate, selectedDate = this.state.selectedDate) => {
     const {
@@ -418,7 +426,7 @@ class CalendarStrip extends Component {
       scrollable,
       minDate,
       maxDate,
-      onWeekChanged,
+      onWeekChanged
     } = this.props;
     let _startingDate = startingDate;
     let days = [];
@@ -429,7 +437,7 @@ class CalendarStrip extends Component {
     if (scrollable) {
       numDays = this.numDaysScroll;
       // Center start date in scroller.
-      _startingDate = startingDate.clone().subtract(numDays/2, "days");
+      _startingDate = startingDate.clone().subtract(numDays / 2, "days");
       if (minDate && _startingDate.isBefore(minDate, "day")) {
         _startingDate = moment(minDate);
       }
@@ -450,50 +458,52 @@ class CalendarStrip extends Component {
         if (date.isSame(startingDate, "day")) {
           initialScrollerIndex = i;
         }
-        datesList.push({date});
-      }
-      else {
-        days.push(this.renderDay({
-          date,
-          key: date.format("YYYY-MM-DD"),
-          ...this.createDayProps(selectedDate),
-        }));
-        datesList.push({date});
+        datesList.push({ date });
+      } else {
+        days.push(
+          this.renderDay({
+            date,
+            key: date.format("YYYY-MM-DD"),
+            ...this.createDayProps(selectedDate)
+          })
+        );
+        datesList.push({ date });
       }
     }
 
     const weekStartDate = datesList[0].date;
     const weekEndDate = datesList[this.state.numVisibleDays - 1].date;
-    onWeekChanged && onWeekChanged(weekStartDate, weekEndDate);
+    //return cloned moment dates rather than internal moment objects
+    onWeekChanged && onWeekChanged(moment(weekStartDate), moment(weekEndDate));
 
     return {
       days,
       datesList,
       initialScrollerIndex,
       weekStartDate,
-      weekEndDate,
+      weekEndDate
     };
-  }
+  };
 
   renderDay(props) {
-    return (
-      <CalendarDay {...props} />
-    );
+    return <CalendarDay {...props} />;
   }
 
   renderHeader() {
-    return ( this.props.showMonth &&
-      <CalendarHeader
-        calendarHeaderFormat={this.props.calendarHeaderFormat}
-        calendarHeaderContainerStyle={this.props.calendarHeaderContainerStyle}
-        calendarHeaderStyle={this.props.calendarHeaderStyle}
-        onHeaderSelected={this.props.onHeaderSelected}
-        weekStartDate={this.state.weekStartDate}
-        weekEndDate={this.state.weekEndDate}
-        fontSize={this.state.monthFontSize}
-        allowHeaderTextScaling={this.props.shouldAllowFontScaling}
-        headerText={this.props.headerText}
-      />
+    return (
+      this.props.showMonth && (
+        <CalendarHeader
+          calendarHeaderFormat={this.props.calendarHeaderFormat}
+          calendarHeaderContainerStyle={this.props.calendarHeaderContainerStyle}
+          calendarHeaderStyle={this.props.calendarHeaderStyle}
+          onHeaderSelected={this.props.onHeaderSelected}
+          weekStartDate={this.state.weekStartDate}
+          weekEndDate={this.state.weekEndDate}
+          fontSize={this.state.monthFontSize}
+          allowHeaderTextScaling={this.props.shouldAllowFontScaling}
+          headerText={this.props.headerText}
+        />
+      )
     );
   }
 
@@ -501,10 +511,10 @@ class CalendarStrip extends Component {
     if (this.props.scrollable && this.state.datesList.length) {
       return (
         <Scroller
-          ref={scroller => this.scroller = scroller}
+          ref={scroller => (this.scroller = scroller)}
           data={this.state.datesList}
           renderDay={this.renderDay}
-          renderDayParams={{...this.createDayProps(this.state.selectedDate)}}
+          renderDayParams={{ ...this.createDayProps(this.state.selectedDate) }}
           maxSimultaneousDays={this.numDaysScroll}
           initialRenderIndex={this.state.initialScrollerIndex}
           minDate={this.props.minDate}
@@ -530,9 +540,9 @@ class CalendarStrip extends Component {
         ]}
       >
         <View style={[this.props.innerStyle, { height: this.state.height }]}>
-          {this.props.showDate && this.props.calendarHeaderPosition === "above" &&
-            this.renderHeader()
-          }
+          {this.props.showDate &&
+            this.props.calendarHeaderPosition === "above" &&
+            this.renderHeader()}
 
           <View style={styles.datesStrip}>
             <WeekSelector
@@ -549,11 +559,9 @@ class CalendarStrip extends Component {
             />
 
             <View onLayout={this.onLayout} style={styles.calendarDates}>
-              {this.props.showDate ? (
-                this.renderWeekView(this.state.days)
-              ) : (
-                this.renderHeader()
-              )}
+              {this.props.showDate
+                ? this.renderWeekView(this.state.days)
+                : this.renderHeader()}
             </View>
 
             <WeekSelector
@@ -570,9 +578,9 @@ class CalendarStrip extends Component {
             />
           </View>
 
-          {this.props.showDate && this.props.calendarHeaderPosition === "below" &&
-            this.renderHeader()
-          }
+          {this.props.showDate &&
+            this.props.calendarHeaderPosition === "below" &&
+            this.renderHeader()}
         </View>
       </View>
     );

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -21,6 +21,7 @@ export default class CalendarScroller extends Component {
     maxDate: PropTypes.any,
     maxSimultaneousDays: PropTypes.number,
     updateMonthYear: PropTypes.func,
+    onWeekChanged: PropTypes.func,
   }
 
   static defaultProps = {
@@ -168,15 +169,30 @@ export default class CalendarScroller extends Component {
       data,
       numDays,
       numVisibleItems,
+      visibleStartDate: _visStartDate,
+      visibleEndDate: _visEndDate,
     } = this.state;
     const visibleStartIndex = all[0];
     const visibleStartDate = data[visibleStartIndex].date;
-    const visibleEndDate = data[all[all.length - 1]].date;
+    const visibleEndIndex = Math.min(visibleStartIndex + numVisibleItems - 1, data.length - 1);
+    const visibleEndDate = data[visibleEndIndex].date;
 
     const {
       updateMonthYear,
+      onWeekChanged,
     } = this.props;
-    updateMonthYear && updateMonthYear(visibleStartDate, visibleEndDate);
+
+    // Fire month/year update on both week and month changes.  This is
+    // necessary for the header and onWeekChanged updates.
+    if (!_visStartDate || !_visEndDate ||
+        !visibleStartDate.isSame(_visStartDate, "week") ||
+        !visibleEndDate.isSame(_visEndDate, "week") ||
+        !visibleStartDate.isSame(_visStartDate, "month") ||
+        !visibleEndDate.isSame(_visEndDate, "month") )
+    {
+      updateMonthYear && updateMonthYear(visibleStartDate, visibleEndDate);
+      onWeekChanged && onWeekChanged(visibleStartDate, visibleEndDate);
+    }
 
     if (visibleStartIndex === 0) {
       this.shiftDaysBackward(visibleStartDate);

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -8,7 +8,11 @@
 import React, { Component } from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
-import { RecyclerListView, DataProvider, LayoutProvider } from "recyclerlistview";
+import {
+  RecyclerListView,
+  DataProvider,
+  LayoutProvider
+} from "recyclerlistview";
 import moment from "moment";
 
 export default class CalendarScroller extends Component {
@@ -21,12 +25,12 @@ export default class CalendarScroller extends Component {
     maxDate: PropTypes.any,
     maxSimultaneousDays: PropTypes.number,
     updateMonthYear: PropTypes.func,
-    onWeekChanged: PropTypes.func,
-  }
+    onWeekChanged: PropTypes.func
+  };
 
   static defaultProps = {
     data: [],
-    renderDayParams: {},
+    renderDayParams: {}
   };
 
   constructor(props) {
@@ -46,7 +50,7 @@ export default class CalendarScroller extends Component {
       );
 
       return { layoutProvider, itemHeight, itemWidth };
-    }
+    };
 
     this.dataProvider = new DataProvider((r1, r2) => {
       return r1 !== r2;
@@ -56,13 +60,13 @@ export default class CalendarScroller extends Component {
       return {
         data,
         numDays: data.length,
-        dataProvider: this.dataProvider.cloneWithRows(data),
-      }
-    }
+        dataProvider: this.dataProvider.cloneWithRows(data)
+      };
+    };
 
     this.state = {
       ...this.updateLayout(props.renderDayParams),
-      ...this.updateDaysData(props.data),
+      ...this.updateDaysData(props.data)
     };
   }
 
@@ -77,7 +81,7 @@ export default class CalendarScroller extends Component {
 
     if (this.props.data !== prevProps.data) {
       updateState = true;
-      newState = {...newState, ...this.updateDaysData(this.props.data)};
+      newState = { ...newState, ...this.updateDaysData(this.props.data) };
     }
 
     if (updateState) {
@@ -90,42 +94,49 @@ export default class CalendarScroller extends Component {
     if (this.state.visibleStartIndex === 0) {
       return;
     }
-    const newIndex = Math.max(this.state.visibleStartIndex - this.state.numVisibleItems, 0);
+    const newIndex = Math.max(
+      this.state.visibleStartIndex - this.state.numVisibleItems,
+      0
+    );
     this.rlv.scrollToIndex(newIndex, true);
-  }
+  };
 
   // Scroll right, guarding against end index.
   scrollRight = () => {
     const endIndex = this.state.visibleStartIndex + this.state.numVisibleItems;
-    if (endIndex === (this.state.numDays - 1)) {
+    if (endIndex === this.state.numDays - 1) {
       return;
     }
-    const newIndex = Math.min(endIndex, this.state.numDays - 1 - this.state.numVisibleItems);
+    const newIndex = Math.min(
+      endIndex,
+      this.state.numDays - 1 - this.state.numVisibleItems
+    );
     this.rlv.scrollToIndex(newIndex, true);
-  }
+  };
 
   // Shift dates when end of list is reached.
   shiftDaysForward = (visibleStartDate = this.state.visibleStartDate) => {
     const prevVisStart = visibleStartDate.clone();
-    const newStartDate = prevVisStart.clone().subtract(Math.floor(this.state.numDays / 3), "days");
+    const newStartDate = prevVisStart
+      .clone()
+      .subtract(Math.floor(this.state.numDays / 3), "days");
     this.updateDays(prevVisStart, newStartDate);
-  }
+  };
 
   // Shift dates when beginning of list is reached.
-  shiftDaysBackward = (visibleStartDate) => {
+  shiftDaysBackward = visibleStartDate => {
     const prevVisStart = visibleStartDate.clone();
-    const newStartDate = prevVisStart.clone().subtract(Math.floor(this.state.numDays * 2/3), "days");
+    const newStartDate = prevVisStart
+      .clone()
+      .subtract(Math.floor(this.state.numDays * 2 / 3), "days");
     this.updateDays(prevVisStart, newStartDate);
-  }
+  };
 
   updateDays = (prevVisStart, newStartDate) => {
     if (this.shifting) {
       return;
     }
-    const {
-      minDate,
-      maxDate,
-    } = this.props;
+    const { minDate, maxDate } = this.props;
     const data = [];
     let _newStartDate = newStartDate;
     if (minDate && newStartDate.isBefore(minDate, "day")) {
@@ -136,7 +147,7 @@ export default class CalendarScroller extends Component {
       if (maxDate && date.isAfter(maxDate, "day")) {
         break;
       }
-      data.push({date});
+      data.push({ date });
     }
     // Prevent reducing range when the minDate - maxDate range is small.
     if (data.length < this.props.maxSimultaneousDays) {
@@ -159,9 +170,9 @@ export default class CalendarScroller extends Component {
     }
     this.setState({
       data,
-      dataProvider: this.dataProvider.cloneWithRows(data),
+      dataProvider: this.dataProvider.cloneWithRows(data)
     });
-  }
+  };
 
   // Track which dates are visible.
   onVisibleIndicesChanged = (all, now, notNow) => {
@@ -170,28 +181,32 @@ export default class CalendarScroller extends Component {
       numDays,
       numVisibleItems,
       visibleStartDate: _visStartDate,
-      visibleEndDate: _visEndDate,
+      visibleEndDate: _visEndDate
     } = this.state;
     const visibleStartIndex = all[0];
     const visibleStartDate = data[visibleStartIndex].date;
-    const visibleEndIndex = Math.min(visibleStartIndex + numVisibleItems - 1, data.length - 1);
+    const visibleEndIndex = Math.min(
+      visibleStartIndex + numVisibleItems - 1,
+      data.length - 1
+    );
     const visibleEndDate = data[visibleEndIndex].date;
 
-    const {
-      updateMonthYear,
-      onWeekChanged,
-    } = this.props;
+    const { updateMonthYear, onWeekChanged } = this.props;
 
     // Fire month/year update on both week and month changes.  This is
     // necessary for the header and onWeekChanged updates.
-    if (!_visStartDate || !_visEndDate ||
-        !visibleStartDate.isSame(_visStartDate, "week") ||
-        !visibleEndDate.isSame(_visEndDate, "week") ||
-        !visibleStartDate.isSame(_visStartDate, "month") ||
-        !visibleEndDate.isSame(_visEndDate, "month") )
-    {
+    if (
+      !_visStartDate ||
+      !_visEndDate ||
+      !visibleStartDate.isSame(_visStartDate, "week") ||
+      !visibleEndDate.isSame(_visEndDate, "week") ||
+      !visibleStartDate.isSame(_visStartDate, "month") ||
+      !visibleEndDate.isSame(_visEndDate, "month")
+    ) {
       updateMonthYear && updateMonthYear(visibleStartDate, visibleEndDate);
-      onWeekChanged && onWeekChanged(visibleStartDate, visibleEndDate);
+      //return cloned moment dates rather than internal moment objects
+      onWeekChanged &&
+        onWeekChanged(moment(visibleStartDate), moment(visibleEndDate));
     }
 
     if (visibleStartIndex === 0) {
@@ -210,23 +225,29 @@ export default class CalendarScroller extends Component {
     this.setState({
       visibleStartDate,
       visibleEndDate,
-      visibleStartIndex,
+      visibleStartIndex
     });
-  }
+  };
 
   onLayout = event => {
     let width = event.nativeEvent.layout.width;
     this.setState({
-      numVisibleItems: Math.floor(width / this.state.itemWidth),
+      numVisibleItems: Math.floor(width / this.state.itemWidth)
     });
-  }
+  };
 
   rowRenderer = (type, data, i, extState) => {
-    return this.props.renderDay && this.props.renderDay({...data, ...extState});
-  }
+    return (
+      this.props.renderDay && this.props.renderDay({ ...data, ...extState })
+    );
+  };
 
   render() {
-    if (!this.state.data || this.state.numDays === 0 || !this.state.itemHeight) {
+    if (
+      !this.state.data ||
+      this.state.numDays === 0 ||
+      !this.state.itemHeight
+    ) {
       return null;
     }
     return (
@@ -235,7 +256,7 @@ export default class CalendarScroller extends Component {
         onLayout={this.onLayout}
       >
         <RecyclerListView
-          ref={rlv => this.rlv = rlv}
+          ref={rlv => (this.rlv = rlv)}
           layoutProvider={this.state.layoutProvider}
           dataProvider={this.state.dataProvider}
           rowRenderer={this.rowRenderer}
@@ -245,7 +266,7 @@ export default class CalendarScroller extends Component {
           isHorizontal
           scrollViewProps={{
             showsHorizontalScrollIndicator: false,
-            contentContainerStyle: {paddingRight: this.state.itemWidth / 2},
+            contentContainerStyle: { paddingRight: this.state.itemWidth / 2 }
           }}
         />
       </View>


### PR DESCRIPTION
I am returning cloned dates for `onDateSelected`, `onWeekChanged` and `onHeaderSelected` callbacks.
I ran `npm run-script format` on the code. I think that is the reason for change in the formatting.

I have made changes in below files

1. CalendarStrip.js:290,477
2. Scroller.js:209
3. CalendarHeader.js:90