### PR TITLE
Dates bounce when component renders #208

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -348,8 +348,8 @@ class CalendarStrip extends Component {
     if (scrollable) {
       numVisibleDays = Math.floor(csWidth / dayComponentWidth);
       // Scroller requires spacing between days
-      marginHorizontal = dayComponentWidth * 0.05;
-      dayComponentWidth = dayComponentWidth * 0.9;
+      marginHorizontal = Math.round(dayComponentWidth * 0.05);
+      dayComponentWidth = Math.round(dayComponentWidth * 0.9);
     }
     let monthFontSize = Math.round(dayComponentWidth / 3.2);
     let selectorSize = Math.round(dayComponentWidth / 2.5);


### PR DESCRIPTION
Fix a rounding error inducing a bounce on ios.

![bounces](https://user-images.githubusercontent.com/486761/87775769-ea186080-c826-11ea-941f-7ebd9e2e7845.gif)
