### PR TITLE
Fix error on unmount: ref null is not an object (evaluating 'n.rlv.scrollToIndex') …

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -32,6 +32,8 @@ export default class CalendarScroller extends Component {
   constructor(props) {
     super(props);
 
+    this.timeoutResetPositionId = null;
+
     this.updateLayout = renderDayParams => {
       const itemHeight = renderDayParams.size;
       const itemWidth = itemHeight + renderDayParams.marginHorizontal * 2;
@@ -65,6 +67,13 @@ export default class CalendarScroller extends Component {
       ...this.updateDaysData(props.data),
       numVisibleItems: 1, // updated in onLayout
     };
+  }
+
+  componentWillUnmount() {
+    if (this.timeoutResetPositionId !== null) {
+      clearTimeout(this.timeoutResetPositionId);
+      this.timeoutResetPositionId = null;
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -151,7 +160,8 @@ export default class CalendarScroller extends Component {
         this.rlv.scrollToIndex(i, false);
         // RecyclerListView sometimes returns position to old index after
         // moving to the new one. Set position again after delay.
-        setTimeout(() => {
+        this.timeoutResetPositionId = setTimeout(() => {
+          this.timeoutResetPositionId = null;
           this.rlv.scrollToIndex(i, false);
           this.shifting = false; // debounce
         }, 800);


### PR DESCRIPTION
Hello,

I found a bug in Scroller component. This bug is triggered in a specific case.

First the user have to reach the limit `data.length < this.props.maxSimultaneousDays` with scroll. Then, when the setTimeout is invoked but not consume yet (800ms), the user unmount the component (i.e. by moving to the screen back).

I think that my explanation is not clear enough so I record the bug.

![Crash null](https://user-images.githubusercontent.com/66009541/89515399-5576a200-d7d7-11ea-801f-287a1752c2c6.gif)

I added a `clearTimeout` at the unmount of the component.

Seems to be fixed now.

If something need to be changged in this PR, ask me.

Thanks for your work.

Have a good day

