### PR TITLE
Change proptypes of imageSource in WeekSelector

### DIFF
--- a/src/WeekSelector.js
+++ b/src/WeekSelector.js
@@ -23,7 +23,7 @@ class WeekSelector extends Component {
       PropTypes.number,
       PropTypes.array
     ]),
-    imageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+    imageSource: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]),
     size: PropTypes.number,
     onPress: PropTypes.func,
     weekStartDate: PropTypes.object,


### PR DESCRIPTION
Using Expo, running in web browser.
Warnings displayed for the original proptypes of imageSource:

index.js:1 Warning: Failed prop type: Invalid prop `imageSource` supplied to `WeekSelector`.
    in WeekSelector (at CalendarStrip.js:553)
    in CalendarStrip (at LogScreen.js:11)
    in div (created by View)
    in View (at LogScreen.js:10)
    in LogScreen (created by SceneView)
    in StaticContainer
    in StaticContainer (created by SceneView)
    in EnsureSingleNavigator (created by SceneView)
    in SceneView (created by CardContainer)
    in div (created by View)
    in View (created by CardContainer)
    in div (created by View)
    in View (created by CardContainer)
    in div (created by View)
    in View (created by ForwardRef(CardSheet))
    in ForwardRef(CardSheet) (created by Card)
    in div (created by View)
    in View (created by AnimatedComponent)
    in AnimatedComponent (created by Card)
    in Dummy (created by Card)
    in div (created by View)
    in View (created by AnimatedComponent)
    in AnimatedComponent (created by Card)
    in div (created by View)
    in View (created by Card)
    in Card (created by CardContainer)
    in CardContainer (created by Context.Consumer)
    in div (created by View)
    in View (created by WebScreen)
    in WebScreen (created by AnimatedComponent)
    in AnimatedComponent (created by MaybeScreen)
    in MaybeScreen (created by Context.Consumer)
    in div (created by View)
    in View (created by MaybeScreenContainer)
    in MaybeScreenContainer (created by Context.Consumer)
    in CardStack (created by KeyboardManager)
    in KeyboardManager (created by Context.Consumer)
    in div (created by View)
    in View (created by NativeSafeAreaView)
    in NativeSafeAreaView (created by SafeAreaProvider)
    in SafeAreaProvider (created by Context.Consumer)
    in SafeAreaProviderCompat (created by StackView)
    in div (created by View)
    in View (created by StackView)
    in StackView (created by StackNavigator)
    in StackNavigator (at App.js:14)
    in EnsureSingleNavigator (created by ForwardRef(BaseNavigationContainer))
    in ForwardRef(BaseNavigationContainer) (created by ForwardRef(NavigationContainer))
    in ThemeProvider (created by ForwardRef(NavigationContainer))
    in ForwardRef(NavigationContainer) (at App.js:13)
    in App (created by ExpoRootComponent)
    in div (created by View)
    in View (at NativeAppearance.web.tsx:51)
    in NativeAppearanceProvider (at src/index.tsx:70)
    in AppearanceProvider (created by ExpoRootComponent)
    in ExpoRootComponent (created by RootComponent)
    in RootComponent
    in div (created by View)
    in View (created by AppContainer)
    in div (created by View)
    in View (created by AppContainer)
    in AppContainer