### PR TITLE
Defining properties as optional.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,10 @@ declare module "react-native-calendar-strip" {
     duration: number;
     borderWidth: number;
     borderHighlightColor: string;
-    animType: any;
-    animUpdateType: any;
-    animProperty: any;
-    animSpringDamping: any;
+    animType?: any;
+    animUpdateType?: any;
+    animProperty?: any;
+    animSpringDamping?: any;
   }
 
   interface IDaySelectionAnimationBackground {


### PR DESCRIPTION
Correction for following the [documentation](https://github.com/ronaldaraujo/react-native-calendar-strip#day-selection-animation-options).