### PR TITLE
Typescript issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,7 @@ declare module "react-native-calendar-strip" {
       maxDate?: Date;
       datesWhitelist?: TDateRange[] | (date: Date) => void;
       datesBlacklist?: TDateRange[] | (date: Date) => void;
+      markedDates?: any[] | (date: Date) => void;
 
       showMonth?: boolean;
       showDayName?: boolean;
@@ -126,6 +127,7 @@ declare module "react-native-calendar-strip" {
       highlightDateNumberStyle?: StyleProp<TextStyle>;
       disabledDateNameStyle?: StyleProp<TextStyle>;
       disabledDateNumberStyle?: StyleProp<TextStyle>;
+      markedDatesStyle: StyleProp<TextStyle>;
       disabledDateOpacity?: number;
       styleWeekend?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ declare module "react-native-calendar-strip" {
       highlightDateNumberStyle?: StyleProp<TextStyle>;
       disabledDateNameStyle?: StyleProp<TextStyle>;
       disabledDateNumberStyle?: StyleProp<TextStyle>;
-      markedDatesStyle: StyleProp<TextStyle>;
+      markedDatesStyle?: StyleProp<TextStyle>;
       disabledDateOpacity?: number;
       styleWeekend?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module "react-native-calendar-strip" {
     size: number;
     allowDayTextScaling: boolean;
     markedDatesStyle: TextStyle;
-    markedDates?: any[] | ((date: Date) => void);
+    markedDates?: any[] | ((date: Moment) => void);
   }
 
   type TDaySelectionAnimation =
@@ -60,8 +60,8 @@ declare module "react-native-calendar-strip" {
     | IDaySelectionAnimationBackground;
 
   type TDateRange = {
-    start: Date;
-    end: Date;
+    start: Moment;
+    end: Moment;
   };
 
   class ReactNativeCalendarStrip extends Component<
@@ -72,18 +72,18 @@ declare module "react-native-calendar-strip" {
 
       numDaysInWeek?: number;
       scrollable?: boolean;
-      startingDate?: Date;
-      selectedDate?: Date;
+      startingDate?: Moment;
+      selectedDate?: Moment;
       onDateSelected?: ((date: Moment) => void);
       onWeekChanged?: ((start: Moment, end: Moment) => void);
-      onHeaderSelected?: (({weekStartDate: Moment, weekEndDate: Moment}) => void);
+      onHeaderSelected?: ((dates: {weekStartDate: Moment, weekEndDate: Moment}) => void);
       updateWeek?: boolean;
       useIsoWeekday?: boolean;
-      minDate?: Date;
-      maxDate?: Date;
-      datesWhitelist?: TDateRange[] | ((date: Date) => void);
-      datesBlacklist?: TDateRange[] | ((date: Date) => void);
-      markedDates?: any[] | ((date: Date) => void);
+      minDate?: Moment;
+      maxDate?: Moment;
+      datesWhitelist?: TDateRange[] | ((date: Moment) => void);
+      datesBlacklist?: TDateRange[] | ((date: Moment) => void);
+      markedDates?: any[] | ((date: Moment) => void);
 
       showMonth?: boolean;
       showDayName?: boolean;
@@ -114,7 +114,7 @@ declare module "react-native-calendar-strip" {
       };
       daySelectionAnimation?: TDaySelectionAnimation;
 
-      customDatesStyles?: any[] | ((date: Date) => void);
+      customDatesStyles?: any[] | ((date: Moment) => void);
 
       dayComponent?: (props: IDayComponentProps) => ReactNode;
 
@@ -137,10 +137,10 @@ declare module "react-native-calendar-strip" {
     {}
   > {
     getSelectedDate: () => undefined | Date | string;
-    setSelectedDate: (date: Date | string) => void;
+    setSelectedDate: (date: Moment | string) => void;
     getNextWeek: () => void;
     getPreviousWeek: () => void;
-    updateWeekView: (date: Date | string, startDate: Date | string) => void;
+    updateWeekView: (date: Moment | string, startDate: Moment | string) => void;
   }
 
   export = ReactNativeCalendarStrip;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from "react";
-import { Duration } from "moment";
+import { Duration, Moment } from "moment";
 import {
   StyleProp,
   ViewStyle,
@@ -75,8 +75,8 @@ declare module "react-native-calendar-strip" {
       scrollable?: boolean;
       startingDate?: Date;
       selectedDate?: Date;
-      onDateSelected?: (date: Date) => void;
-      onWeekChanged?: (start: Date, end: Date) => void;
+      onDateSelected?: (date: Moment) => void;
+      onWeekChanged?: (start: Moment, end: Moment) => void;
       onHeaderSelected?: ({weekStartDate: Date, weekEndDate: Date}) => void;
       updateWeek?: boolean;
       useIsoWeekday?: boolean;


### PR DESCRIPTION
Missing those two props on CalendarStrip component. 

Moment is send on callback `onDateSelected` and `onWeekChanged` making errors if we do a `date.toDateString()` on the function.