### PR TITLE
Fix typescript linting errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare module "react-native-calendar-strip" {
     size: number;
     allowDayTextScaling: boolean;
     markedDatesStyle: TextStyle;
-    markedDates?: any[] | (date: Date) => void;
+    markedDates?: any[] | ((date: Date) => void);
   }
 
   type TDaySelectionAnimation =
@@ -82,8 +82,8 @@ declare module "react-native-calendar-strip" {
       useIsoWeekday?: boolean;
       minDate?: Date;
       maxDate?: Date;
-      datesWhitelist?: TDateRange[] | (date: Date) => void;
-      datesBlacklist?: TDateRange[] | (date: Date) => void;
+      datesWhitelist?: TDateRange[] | ((date: Date) => void);
+      datesBlacklist?: TDateRange[] | ((date: Date) => void);
 
       showMonth?: boolean;
       showDayName?: boolean;
@@ -114,7 +114,7 @@ declare module "react-native-calendar-strip" {
       };
       daySelectionAnimation?: TDaySelectionAnimation;
 
-      customDatesStyles?: any[] | (date: Date) => void;
+      customDatesStyles?: any[] | ((date: Date) => void);
 
       dayComponent?: (props: IDayComponentProps) => ReactNode;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ declare module "react-native-calendar-strip" {
       selectedDate?: Date;
       onDateSelected?: (date: Date) => void;
       onWeekChanged?: (start: Date, end: Date) => void;
-      onHeaderSelected?: ({weekStartDate: Date, weekEndDate: Date}) => void;
+      onHeaderSelected?: (dates: {weekStartDate: Date, weekEndDate: Date}) => void;
       updateWeek?: boolean;
       useIsoWeekday?: boolean;
       minDate?: Date;


### PR DESCRIPTION
Fix #214 issue.  
When we run `$ tsc index.d.ts` command, TypeScript no longer throws up linting errors.  
