### PR TITLE
Forward externalScrollView prop to RecyclerListView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, ReactNode } from "react";
+import { Component, ReactNode, ComponentProps } from "react";
 import { Duration } from "moment";
 import {
   StyleProp,
@@ -6,6 +6,7 @@ import {
   TextStyle,
   GestureResponderEvent
 } from "react-native";
+import { RecyclerListView } from 'recyclerlistview';
 
 declare module "react-native-calendar-strip" {
   interface IDaySelectionAnimationBorder {
@@ -73,6 +74,7 @@ declare module "react-native-calendar-strip" {
 
       numDaysInWeek?: number;
       scrollable?: boolean;
+      externalScrollView?: ComponentProps<typeof RecyclerListView>['externalScrollView'];	
       startingDate?: Date;
       selectedDate?: Date;
       onDateSelected?: (date: Date) => void;

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -26,6 +26,7 @@ class CalendarStrip extends Component {
 
     numDaysInWeek: PropTypes.number,
     scrollable: PropTypes.bool,
+    externalScrollView: PropTypes.func,
     startingDate: PropTypes.any,
     selectedDate: PropTypes.any,
     onDateSelected: PropTypes.func,
@@ -522,6 +523,7 @@ class CalendarStrip extends Component {
           maxDate={this.props.maxDate}
           updateMonthYear={this.updateMonthYear}
           onWeekChanged={this.props.onWeekChanged}
+          externalScrollView={this.props.externalScrollView}
         />
       );
     }

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -22,6 +22,7 @@ export default class CalendarScroller extends Component {
     maxSimultaneousDays: PropTypes.number,
     updateMonthYear: PropTypes.func,
     onWeekChanged: PropTypes.func,
+    externalScrollView: PropTypes.func
   }
 
   static defaultProps = {
@@ -258,6 +259,7 @@ export default class CalendarScroller extends Component {
           initialRenderIndex={this.props.initialRenderIndex}
           onVisibleIndicesChanged={this.onVisibleIndicesChanged}
           isHorizontal
+          externalScrollView={this.props.externalScrollView}
           scrollViewProps={{
             showsHorizontalScrollIndicator: false,
             contentContainerStyle: {paddingRight: this.state.itemWidth / 2},


### PR DESCRIPTION
This is useful if you want to replace ScrollView with something else. 
For example you may want to sub in the ScrollView from `react-native-gesture-handler` if you are using it inside of a bottom sheet https://github.com/osdnk/react-native-reanimated-bottom-sheet.