### PR TITLE
Changes to blacklist/whitelist should force a refresh

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -154,7 +154,9 @@ class CalendarStrip extends Component {
     let updateState = false;
 
     if (!this.compareDates(prevProps.startingDate, this.props.startingDate) ||
-        !this.compareDates(prevProps.selectedDate, this.props.selectedDate))
+        !this.compareDates(prevProps.selectedDate, this.props.selectedDate) ||
+        prevProps.datesBlacklist !== this.props.datesBlacklist ||
+        prevProps.datesWhitelist !== this.props.datesWhitelist)
     {
       updateState = true;
       startingDate = { startingDate: this.setLocale(this.props.startingDate)};


### PR DESCRIPTION
I am working on a project where whitelisted/blacklisted dates of a calendar strip are dynamic. In the current version of this component, changes to the whitelists and blacklists are not rendered until a `CalendarDay` element is clicked, which is rather confusing. This PR forces a componentwide refresh when these lists change. 

I'm not sure if it's strictly necessary to recompute `startingDate`, `selectedDate`, and `days`.