### PR TITLE
allow text of the days to be title case

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`disabledDateOpacity`**      | Opacity of disabled dates strip.                                                                                                           | Number         | **`0.3`**  |
 | **`customDatesStyles`**        | Custom per-date styling, overriding the styles above. Check Table <a href="#customdatesstyles"> Below </a>     .                           | Array or Func  | [] |
 | **`shouldAllowFontScaling`**   | Override the underlying Text element scaling to respect font settings                                                                      | Bool           | **`True`**|
-| **`upperCaseDays`**   | Toggle text formatting of days between uppercase and title case | Bool | **`True`**|
+| **`upperCaseDays`**   | Format text of the days to upper case or title case | Bool | **`True`**|
 
 #### customDatesStyles
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ AppRegistry.registerComponent('Example', () => Example);
 | **`disabledDateOpacity`**      | Opacity of disabled dates strip.                                                                                                           | Number         | **`0.3`**  |
 | **`customDatesStyles`**        | Custom per-date styling, overriding the styles above. Check Table <a href="#customdatesstyles"> Below </a>     .                           | Array or Func  | [] |
 | **`shouldAllowFontScaling`**   | Override the underlying Text element scaling to respect font settings                                                                      | Bool           | **`True`**|
+| **`upperCaseDays`**   | Toggle text formatting of days between uppercase and title case | Bool | **`True`**|
 
 #### customDatesStyles
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ interface IDayComponentProps {
   allowDayTextScaling?: boolean;
   markedDatesStyle?: TextStyle;
   markedDates?: any[] | ((date: Moment) => void);
+  upperCaseDays?: boolean;
 }
 
 type TDaySelectionAnimation =
@@ -135,6 +136,7 @@ interface CalendarStripProps {
   markedDatesStyle?: StyleProp<TextStyle>;
   disabledDateOpacity?: number;
   styleWeekend?: boolean;
+  upperCaseDays?: boolean;
 
   locale?: object;
   shouldAllowFontScaling?: boolean;

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -50,6 +50,7 @@ class CalendarDay extends Component {
     daySelectionAnimation: PropTypes.object,
     useNativeDriver: PropTypes.bool,
     scrollable: PropTypes.bool,
+    upperCaseDays: PropTypes.bool,
   };
 
   // Reference: https://medium.com/@Jpoliachik/react-native-s-layoutanimation-is-awesome-4a4d317afd3e
@@ -67,7 +68,8 @@ class CalendarDay extends Component {
     },
     styleWeekend: true,
     showDayName: true,
-    showDayNumber: true
+    showDayNumber: true,
+    upperCaseDays: true,
   };
 
   constructor(props) {
@@ -379,6 +381,7 @@ class CalendarDay extends Component {
       allowDayTextScaling,
       dayComponent: DayComponent,
       scrollable,
+      upperCaseDays,
     } = this.props;
     const {
       enabled,
@@ -485,7 +488,7 @@ class CalendarDay extends Component {
                 style={[{ fontSize: dateNameFontSize }, _dateNameStyle]}
                 allowFontScaling={allowDayTextScaling}
               >
-                {date.format("ddd").toUpperCase()}
+                {upperCaseDays ? date.format("ddd").toUpperCase() : date.format("ddd")}
               </Text>
             )}
             {showDayNumber && (

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -91,7 +91,8 @@ class CalendarStrip extends Component {
 
     locale: PropTypes.object,
     shouldAllowFontScaling: PropTypes.bool,
-    useNativeDriver: PropTypes.bool
+    useNativeDriver: PropTypes.bool,
+    upperCaseDays: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -116,6 +117,7 @@ class CalendarStrip extends Component {
     markedDates: [],
     useNativeDriver: true,
     scrollToOnSetSelectedDate: true,
+    upperCaseDays: true,
   };
 
   constructor(props) {
@@ -445,6 +447,7 @@ class CalendarStrip extends Component {
       width: this.state.dayComponentWidth,
       marginHorizontal: this.state.marginHorizontal,
       allowDayTextScaling: this.props.shouldAllowFontScaling,
+      upperCaseDays: this.props.upperCaseDays,
     }
   }
 


### PR DESCRIPTION
added an `upperCaseDays` prop (`true` by default) which sets the text of the day to title case when set to `false`

fixes #265 
