### PR TITLE
fixed shown wrong selected date when using updateWeekView immediately after call setSelectedDate.

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -306,7 +306,7 @@ class CalendarStrip extends Component {
         ...this.createDays(this.state.startingDate, selectedDate),
       };
     }
-    this.setState(newState);
+    this.setState(() => newState);
     const _selectedDate = selectedDate && selectedDate.clone();
     this.props.onDateSelected && this.props.onDateSelected(_selectedDate);
   }


### PR DESCRIPTION
Fixed a bug where calling updateWeekView immediately after calling setSelectedDate would display an unintended date.
It was because setState was running asynchronously.

It is reenact with the following code.
https://snack.expo.io/E4K9r9rrQ