### PR TITLE
Fixing no-op: evaluating 'datesList[_this.state.numVisibleDays - 1].date'

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -155,6 +155,10 @@ class CalendarStrip extends Component {
 
   //Receiving props and set date states, minimizing state updates.
   componentDidUpdate(prevProps, prevState) {
+    if (!this.state.dayComponentWidth) {
+      return
+    }
+    
     let startingDate = {};
     let selectedDate = {};
     let days = {};

--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -146,7 +146,8 @@ class CalendarStrip extends Component {
       dayComponentWidth: 0,
       height: 0,
       monthFontSize: 0,
-      selectorSize: 0
+      selectorSize: 0,
+      numVisibleDays: props.numDaysInWeek,
     };
 
     this.animations = [];
@@ -155,10 +156,6 @@ class CalendarStrip extends Component {
 
   //Receiving props and set date states, minimizing state updates.
   componentDidUpdate(prevProps, prevState) {
-    if (!this.state.dayComponentWidth) {
-      return
-    }
-    
     let startingDate = {};
     let selectedDate = {};
     let days = {};


### PR DESCRIPTION
Fix suggested here: https://github.com/BugiDev/react-native-calendar-strip/issues/303#issuecomment-864510769