### PR TITLE
Highlight date container style override fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ interface CalendarStripProps {
 
   dayComponent?: (props: IDayComponentProps) => ReactNode;
 
+  dayContainerStyle?: StyleProp<ViewStyle>;
   dateNameStyle?: StyleProp<TextStyle>;
   dateNumberStyle?: StyleProp<TextStyle>;
   weekendDateNameStyle?: StyleProp<TextStyle>;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "Peace Chen (https://github.com/peacechen)",
     "Sam Colby (https://github.com/samcolby)",
     "Vitaliy Zhukov (https://github.com/Vitall)",
-    "Dimka Vasilyev (https://github.com/gHashTag)"
+    "Dimka Vasilyev (https://github.com/gHashTag)",
+    "Quinton Chester (https://github.com/QuintonC)"
   ],
   "license": "MIT",
   "homepage": "https://github.com/BugiDev/react-native-calendar-strip#readme",
@@ -19,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/BugiDev/react-native-calendar-strip/issues"
   },
-  "version": "2.2.4",
+  "version": "2.2.5",
   "main": "index.js",
   "directories": {
     "example": "example"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/BugiDev/react-native-calendar-strip/issues"
   },
-  "version": "2.2.5",
+  "version": "2.2.4",
   "main": "index.js",
   "directories": {
     "example": "example"

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -465,6 +465,10 @@ class CalendarDay extends Component {
       borderRadius: containerBorderRadius,
     };
 
+    let containerStyle = selected
+      ? { ...dayContainerStyle, ...highlightDateContainerStyle }
+      : dayContainerStyle;
+
     let day;
     if (DayComponent) {
       day = (<DayComponent {...this.props} {...this.state}/>);
@@ -480,7 +484,7 @@ class CalendarDay extends Component {
               styles.dateContainer,
               responsiveDateContainerStyle,
               _dateViewStyle,
-              dayContainerStyle
+              containerStyle
             ]}
           >
             {showDayName && (


### PR DESCRIPTION
Fixed issue where the highlightDateContainerStyle was overridden by dayContainerStyle. Also added dayContainerStyle to the list of valid props for the package. 