### PR TITLE
Crashfix for CalendarDay having an undefined props.height

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -70,6 +70,8 @@ class CalendarDay extends Component {
     showDayName: true,
     showDayNumber: true,
     upperCaseDays: true,
+    width: 0, // Default width and height to avoid calcSizes() *sometimes* doing Math.round(undefined) to cause NaN
+    height: 0
   };
 
   constructor(props) {


### PR DESCRIPTION
CalendarDay's `calcSizes` calculates a responsive `containerHeight` by doing `Math.round(props.height)`. Ditto for the width. 

During development, `props.height` would sometimes be `undefined`, causing it to do `Math.random(undefined)` which yielded `NaN`. This occurred even when an explicit `dayComponentHeight` was being passed in. That in turn led to the following error, causing an app crash on Android:

```
Invariant Violation: [847,"RCTView",81,{"justifyContent":"center","alignItems":"center","alignSelf":"center","width":0,"height":"<<NaN>>","borderRadius":0,"backgroundColor":0}] is not usable as a native method argument
```

- That's when using JSC and RN 0.64.2. Hermes crashes without a useful error.
- The issue was particularly prevalent when using Fast Refresh. Once it happened I always had to reinstall the app onto the device to get it to work again.
- I noticed `containerWidth` was always `0` in my logs, so I defaulted it to that and chose to do the same with the height. Have not seen any issues so far.
