### PR TITLE
fix(issue 306) library causing crash to the app due to rlv not defined.

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -143,7 +143,7 @@ export default class CalendarScroller extends Component {
 
     for (let i = 0; i < this.state.data.length; i++) {
       if (this.state.data[i].date.isSame(targetDate, "day")) {
-        this.rlv.scrollToIndex(i, true);
+        this.rlv?.scrollToIndex(i, true);
         break;
       }
     }


### PR DESCRIPTION
Simplified version of this pr
https://github.com/BugiDev/react-native-calendar-strip/pull/322