### PR TITLE
[Fix] scrollToOnSetSelectedDate false continuing scrolling

### DIFF
--- a/src/CalendarStrip.js
+++ b/src/CalendarStrip.js
@@ -566,6 +566,7 @@ class CalendarStrip extends Component {
           onWeekScrollStart={this.props.onWeekScrollStart}
           onWeekScrollEnd={this.props.onWeekScrollEnd}
           externalScrollView={this.props.externalScrollView}
+          scrollToOnSetSelectedDate={this.props.scrollToOnSetSelectedDate}
         />
       );
     }

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -25,12 +25,14 @@ export default class CalendarScroller extends Component {
     onWeekScrollStart: PropTypes.func,
     onWeekScrollEnd: PropTypes.func,
     externalScrollView: PropTypes.func,
-    pagingEnabled: PropTypes.bool
+    pagingEnabled: PropTypes.bool,
+    scrollToOnSetSelectedDate: PropTypes.bool
   }
 
   static defaultProps = {
     data: [],
     renderDayParams: {},
+    scrollToOnSetSelectedDate: true
   };
 
   constructor(props) {
@@ -128,6 +130,8 @@ export default class CalendarScroller extends Component {
 
   // Scroll to given date, and check against min and max date if available.
   scrollToDate = (date) => {
+    if (!this.props.scrollToOnSetSelectedDate) return;
+    
     let targetDate = moment(date).subtract(Math.round(this.state.numVisibleItems / 2) - 1, "days");
     const {
       minDate,


### PR DESCRIPTION
When scrollToOnSetSelectedDate was false the calendar continued to scroll. Fixed by adding scrollToOnSetSelectedDate on Scroller.js and validating there too.