### PR TITLE
fix: security issue and bug when remount CalendarStrip

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "moment": ">=2.0.0",
     "node-git-hooks": "^1.0.1",
     "prop-types": "^15.6.0",
-    "recyclerlistview": "^3.0.0"
+    "recyclerlistview": ">3.0.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -113,7 +113,7 @@ export default class CalendarScroller extends Component {
       return;
     }
     const newIndex = Math.max(this.state.visibleStartIndex - this.state.numVisibleItems, 0);
-    this.rlv.scrollToIndex(newIndex, true);
+    this.rlv?.scrollToIndex(newIndex, true);
   }
 
   // Scroll right, guarding against end index.
@@ -123,7 +123,7 @@ export default class CalendarScroller extends Component {
       this.rlv.scrollToEnd(true); // scroll to the very end, including padding
       return;
     }
-    this.rlv.scrollToIndex(newIndex, true);
+    this.rlv?.scrollToIndex(newIndex, true);
   }
 
   // Scroll to given date, and check against min and max date if available.
@@ -192,12 +192,12 @@ export default class CalendarScroller extends Component {
     for (let i = 0; i < data.length; i++) {
       if (data[i].date.isSame(prevVisStart, "day")) {
         this.shifting = true;
-        this.rlv.scrollToIndex(i, false);
+        this.rlv?.scrollToIndex(i, false);
         // RecyclerListView sometimes returns position to old index after
         // moving to the new one. Set position again after delay.
         this.timeoutResetPositionId = setTimeout(() => {
           this.timeoutResetPositionId = null;
-          this.rlv.scrollToIndex(i, false);
+          this.rlv?.scrollToIndex(i, false);
           this.shifting = false; // debounce
         }, 800);
         break;


### PR DESCRIPTION
Output of npm audit

```
node-fetch  <2.6.7
Severity: high
node-fetch forwards secure headers to untrusted sites - https://github.com/advisories/GHSA-r683-j2x4-v87g fix available via `npm audit fix --force`
Will install react-native-calendar-strip@1.4.2, which is a breaking change node_modules/isomorphic-fetch/node_modules/node-fetch
  isomorphic-fetch  2.0.0 - 2.2.1
  Depends on vulnerable versions of node-fetch
  node_modules/isomorphic-fetch
    fbjs  0.7.0 - 1.0.0
    Depends on vulnerable versions of isomorphic-fetch
    node_modules/recyclerlistview/node_modules/fbjs
      prop-types  15.5.0-alpha.0 - 15.6.1
      Depends on vulnerable versions of fbjs
      node_modules/recyclerlistview/node_modules/prop-types
        recyclerlistview  <=4.0.1
        Depends on vulnerable versions of prop-types
        node_modules/recyclerlistview
          react-native-calendar-strip  >=2.0.0
          Depends on vulnerable versions of recyclerlistview
          node_modules/react-native-calendar-strip
```